### PR TITLE
fix: add network config for kodbox

### DIFF
--- a/apps/kodbox/versions/1.37.03/docker-compose.yml
+++ b/apps/kodbox/versions/1.37.03/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     restart: always
     labels:
       createdBy: "Apps"
+    networks:
+      - 1panel-network      
 networks:
   1panel-network:
     external: true


### PR DESCRIPTION
```release-note
fix: add network config for kodbox
```
在 Kodbox 应用的 docker-compose 文件中增加容器网络设置，解决应用部署后与其他 1Panel 部署的应用不在一个网络的问题。