### PR TITLE
refactor: minio 支持设置文件分享地址

### DIFF
--- a/apps/minio/versions/RELEASE.2022-08-13T21-54-44Z/config.json
+++ b/apps/minio/versions/RELEASE.2022-08-13T21-54-44Z/config.json
@@ -37,6 +37,16 @@
       "default": 9001,
       "rule": "paramPort",
       "envKey": "PORT_API"
+    },
+    {
+      "type": "text",
+      "labelZh": "分享文件地址",
+      "labelEn": "SHARE ADRESS",
+      "required": true,
+      "default": "http://localhost",
+      "rule": "paramExtUrl",
+      "envKey": "MINIO_SERVER_URL",
+      "edit": true
     }
   ]
 }

--- a/apps/minio/versions/RELEASE.2022-08-13T21-54-44Z/docker-compose.yml
+++ b/apps/minio/versions/RELEASE.2022-08-13T21-54-44Z/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       environment:
         MINIO_ROOT_USER: ${MINIO_ROOT_USER}
         MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+        MINIO_SERVER_URL: ${MINIO_SERVER_URL}:${PORT_API}
       logging:
         options:
           max-size: "5M"


### PR DESCRIPTION
参数 MINIO_SERVER_URL 主要用于更改服务在分享文件时显示的服务地址，启动服务时直接配置成宿主机 IP，不配置参数分享时默认显示容器内部 IP 地址如：http://172.17.0.3:9001/public/…