### PR TITLE
OLS移除logging

### DIFF
--- a/apps/openlitespeed/1.7.19-lsphp74/docker-compose.yml
+++ b/apps/openlitespeed/1.7.19-lsphp74/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     restart: always
     networks:
       - 1panel-network
-    logging:
-      driver: none
     volumes:
       - ./data/lsws/conf:/usr/local/lsws/conf
       - ./data/lsws/admin-conf:/usr/local/lsws/admin/conf

--- a/apps/openlitespeed/1.7.19-lsphp81/docker-compose.yml
+++ b/apps/openlitespeed/1.7.19-lsphp81/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     restart: always
     networks:
       - 1panel-network
-    logging:
-      driver: none
     volumes:
       - ./data/lsws/conf:/usr/local/lsws/conf
       - ./data/lsws/admin-conf:/usr/local/lsws/admin/conf


### PR DESCRIPTION
移除logging从而防止出现`Error response from daemon: configured logging driver does not support reading`报错导致无法启动