### PR TITLE
修改ddns-go的网络为默认的1panel-network，修复ddns-go设置端口不生效的问题

### DIFF
--- a/apps/ddns-go/6.2.1/docker-compose.yml
+++ b/apps/ddns-go/6.2.1/docker-compose.yml
@@ -3,7 +3,8 @@ services:
   ddns-go:
     container_name: ${CONTAINER_NAME}
     restart: always
-    network_mode: host
+    networks:
+      - 1panel-network
     ports:
       - "${PANEL_APP_PORT_HTTP}:9876"
     volumes:
@@ -11,3 +12,7 @@ services:
     image: jeessy/ddns-go:v6.2.1
     labels:
       createdBy: "Apps"
+
+networks:
+  1panel-network:
+    external: true

--- a/apps/tomcat/data.yml
+++ b/apps/tomcat/data.yml
@@ -1,14 +1,14 @@
-name: Apache Tomcat 
+name: Apache Tomcat
 tags:
-    - 开发工具
+    - 中间件
 title: 开源的 Web 服务器和 Servlet 容器
-type: 开发工具
+type: 中间件
 description: 开源的 Web 服务器和 Servlet 容器
 additionalProperties:
     key: tomcat
-    name: Apache Tomcat 
+    name: Apache Tomcat
     tags:
-        - DevTool
+        - Middleware
     shortDescZh: 开源的 Web 服务器和 Servlet 容器
     shortDescEn: An open-source web server and servlet container
     type: tool

--- a/data.yaml
+++ b/data.yaml
@@ -21,7 +21,7 @@ additionalProperties:
       name: 云存储
       sort: 6
     - key: AI
-      name: AI
+      name: AI/大模型
       sort: 7  
     - key: BI
       name: BI


### PR DESCRIPTION
修改ddns-go的网络为默认的1panel-network，修复ddns-go设置端口不生效的问题