### PR TITLE
add HALO_CACHE_PAGE_DISABLED for Halo

### DIFF
--- a/apps/halo/2.13.1/data.yml
+++ b/apps/halo/2.13.1/data.yml
@@ -58,7 +58,7 @@ additionalProperties:
           required: true
           rule: paramPort
           type: number
-        - default: false
+        - default: "false"
           edit: true
           envKey: HALO_CACHE_PAGE_DISABLED
           labelEn: Whether to disable page caching

--- a/apps/halo/2.13.1/data.yml
+++ b/apps/halo/2.13.1/data.yml
@@ -58,3 +58,11 @@ additionalProperties:
           required: true
           rule: paramPort
           type: number
+        - default: false
+          edit: true
+          envKey: HALO_CACHE_PAGE_DISABLED
+          labelEn: Whether to disable page caching
+          labelZh: 是否禁用页面缓存
+          required: false
+          rule: paramCommon
+          type: text

--- a/apps/halo/2.13.1/docker-compose.yml
+++ b/apps/halo/2.13.1/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - --spring.r2dbc.password=${PANEL_DB_USER_PASSWORD}
       - --spring.sql.init.platform=${PANEL_DB_TYPE}
       - --halo.external-url=${HALO_EXTERNAL_URL}
+      - --halo.cache.page.disabled=${HALO_CACHE_PAGE_DISABLED}
     labels:
       createdBy: "Apps"
 networks:


### PR DESCRIPTION
为Halo添加halo.cache.page.disabled可选参数，开启缓存之后，在登录的情况下不会经过缓存，且默认一个小时会清理掉不活跃的缓存，也可以在 Console 仪表盘的快捷访问中手动清理缓存。