### PR TITLE
update mysql docker tag to v8.4.0

### DIFF
--- a/apps/mysql/8.4.0/conf/my.cnf
+++ b/apps/mysql/8.4.0/conf/my.cnf
@@ -1,0 +1,99 @@
+[mysqld]
+# General Settings
+port = 3306
+user = mysql
+mysqlx = off
+pid_file = /var/lib/mysql/mysqld.pid
+socket = /var/lib/mysql/mysql.sock
+datadir = /var/lib/mysql/
+host_cache_size=0
+skip_name_resolve
+default_time_zone = '+8:00'
+lower_case_table_names = 1
+group_concat_max_len = 1024000
+default_storage_engine = innodb
+secure_file_priv = /var/lib/mysql-files/
+log_error_suppression_list='MY-010068'
+skip_external_locking = on
+
+# Character Sets and Collations
+character_set_server = utf8mb4
+collation_server = utf8mb4_unicode_ci
+
+slow_query_log = on
+slow_query_log_file = /var/lib/mysql/slow_queries.log
+
+# Logging
+log_error = /var/lib/mysql/mysqld_error.log
+log_output = FILE
+
+# _/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
+# Server ID 如果是主从复制环境需要修改
+# _/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
+server_id = 1
+
+# InnoDB Settings
+innodb_buffer_pool_size = 128M      # 需要根据实际内存情况和应用场景配置
+innodb_flush_log_at_trx_commit = 2  # innodb_flush_log_at_trx_commit
+                                    #  - 1: 每次事务提交时都同步事务日志
+                                    #  - 2: 事务提交时写缓存，等checkpoint同步
+                                    # 对数据安全性要求不那么严格的场景可以设为2以提高性能
+innodb_flush_neighbors = 1          # 相邻的页一起刷新到磁盘以提高随即访问性能
+#innodb_buffer_pool_instances = 4   # 线程池数量，是否开启需要根据特定场景在测试后决定
+innodb_flush_method = o_direct      # 机械硬盘/固体硬盘设置不同，同时还跟文件系统有关
+                                    #  - fsync 先写文件系统缓存，再确保缓存落盘后返回，一般机械硬盘使用，确保缓存数据的更新提高读性能
+                                    #  - o_dsync
+                                    #  - o_direct 直接磁盘操作，绕过文件系统缓存，固态硬盘推荐，因为极高的随机读取性能，缓存对读性能影响有限
+                                    #  - all_o_direct
+innodb_io_capacity = 200            # 需要根据实际磁盘情况设定，默认200
+innodb_adaptive_flushing = on       # 根据系统负载和性能需求自动调整刷新行为，以优化性能和稳定性
+innodb_thread_concurrency = 0       # 需要根据具体业务场景测试后设置，默认0
+innodb_stats_on_metadata = on       # OLAP建议关闭，OLTP建议保持默认，默认on
+innodb_lru_scan_depth = 256         # 设置通常在 100 到 1000 之间，具体取决于系统的硬件配置、负载情况和性能要求
+innodb_buffer_pool_chunk_size = 32M # 缓冲池在内存中的分块大小，通常在 128M 到 2G 之间，具体取决于系统的内存大小、负载情况和性能需求
+innodb_fast_shutdown = 0            # 控制数据库关闭行为的参数，对性能影响有限，保持默认，默认0
+                                    #  - 0： 适用于常规关闭，表示数据库将执行完所有的清理和日志写入操作后再关闭
+                                    #  - 1： 表示数据库执行一些额外的快速关闭操作，可以加速数据库关闭的速度
+                                    #  - 2： 表示数据库执行最快速的关闭操作，但可能会牺牲一些数据的一致性
+
+performance_schema = on
+
+# Connection Settings
+max_connections = 100
+max_allowed_packet = 16M
+
+# _/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
+sql_mode = "ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
+
+# Binary Log Settings
+log_bin = on
+log_bin_index = /var/lib/mysql/mysql_bin.index
+# _/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
+# 这个选项在主从复制环境中有一定作用，会在binlog记录函数的创建修改操作，默认关闭
+# _/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
+log_bin_trust_function_creators = 0
+sync_binlog = 1
+
+# Redo Log Settings
+innodb_log_group_home_dir = /var/lib/mysql
+innodb_redo_log_archive_dirs = /var/lib/mysql
+innodb_redo_log_capacity = 128M
+
+# Undo Log Settings
+innodb_undo_directory = /var/lib/mysql
+innodb_max_undo_log_size = 64M
+
+# Relay Log Settings
+relay_log = /var/lib/mysql/relay_bin
+relay_log_index = /var/lib/mysql/relay_bin.index
+
+[client]
+default_character_set = utf8mb4
+socket = /var/lib/mysql/mysql.sock
+
+[mysql]
+default_character_set = utf8mb4
+socket = /var/lib/mysql/mysql.sock
+
+!includedir /etc/mysql/conf.d/
+

--- a/apps/mysql/8.4.0/data.yml
+++ b/apps/mysql/8.4.0/data.yml
@@ -1,0 +1,17 @@
+additionalProperties:
+    formFields:
+        - default: mysql
+          envKey: PANEL_DB_ROOT_PASSWORD
+          labelEn: Root Password
+          labelZh: root用户密码
+          random: true
+          required: true
+          rule: paramComplexity
+          type: password
+        - default: 3306
+          envKey: PANEL_APP_PORT_HTTP
+          labelEn: Port
+          labelZh: 端口
+          required: true
+          rule: paramPort
+          type: number

--- a/apps/mysql/8.4.0/docker-compose.yml
+++ b/apps/mysql/8.4.0/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  mysql:
+    image: mysql:8.4.0
+    container_name: ${CONTAINER_NAME}
+    restart: always
+    environment:
+      - MYSQL_ROOT_PASSWORD=${PANEL_DB_ROOT_PASSWORD}
+      - MYSQL_INITDB_SKIP_TZINFO=1
+      - TZ=Asia/Shanghai
+    networks:
+      - 1panel-network
+    ports:
+      - ${PANEL_APP_PORT_HTTP}:3306
+    volumes:
+      - mysql:/var/lib/mysql/
+      - ./conf/my.cnf:/etc/my.cnf
+    healthcheck:
+      test: mysqladmin ping -h 127.0.0.1 -u root --password=$$MYSQL_ROOT_PASSWORD
+      start_period: 5s
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    labels:
+      createdBy: "Apps"
+
+networks:
+  1panel-network:
+    external: true
+
+volumes:
+  mysql:
+    driver: local

--- a/apps/mysql/8.4.0/docker-compose.yml
+++ b/apps/mysql/8.4.0/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - ${PANEL_APP_PORT_HTTP}:3306
     volumes:
-      - mysql:/var/lib/mysql/
+      - ./data/:/var/lib/mysql/
       - ./conf/my.cnf:/etc/my.cnf
     healthcheck:
       test: mysqladmin ping -h 127.0.0.1 -u root --password=$$MYSQL_ROOT_PASSWORD
@@ -26,7 +26,3 @@ services:
 networks:
   1panel-network:
     external: true
-
-volumes:
-  mysql:
-    driver: local


### PR DESCRIPTION
* 升级mysql到8.4.0
* 优化配置文件
* 增加healthcheck
* 使用命名卷方便其他应用通过unix套接字连接

现在安装初始化到启动服务的日志已经非常干净了
```
2024-05-08 18:53:51+08:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.4.0-1.el9 started.
2024-05-08 18:53:53+08:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
2024-05-08 18:53:53+08:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.4.0-1.el9 started.
2024-05-08 18:53:54+08:00 [Note] [Entrypoint]: Initializing database files
2024-05-08 18:54:26+08:00 [Note] [Entrypoint]: Database files initialized
2024-05-08 18:54:26+08:00 [Note] [Entrypoint]: Starting temporary server
2024-05-08 18:54:30+08:00 [Note] [Entrypoint]: Temporary server started.

2024-05-08 18:54:30+08:00 [Note] [Entrypoint]: Stopping temporary server
2024-05-08 18:54:32+08:00 [Note] [Entrypoint]: Temporary server stopped

2024-05-08 18:54:32+08:00 [Note] [Entrypoint]: MySQL init process done. Ready for start up.

```