### PR TITLE
修复pg数据库的value值

### DIFF
--- a/apps/firefly-iii/6.1.15/data.yml
+++ b/apps/firefly-iii/6.1.15/data.yml
@@ -21,7 +21,7 @@ additionalProperties:
             - label: MySQL
               value: mysql
             - label: PostgreSQL
-              value: pgsql
+              value: postgres
         - default: firefly
           envKey: PANEL_DB_NAME
           labelEn: Database


### PR DESCRIPTION
原配置会请求/api/v1/apps/services/pgsql，造成服务内部错误: record not found