### PR TITLE
Correct WebSite to Website

### DIFF
--- a/apps/answer/data.yml
+++ b/apps/answer/data.yml
@@ -7,7 +7,7 @@ additionalProperties:
     key: answer
     name: Answer
     tags:
-        - WebSite
+        - Website
     shortDescZh: 适用于任何规模团队的问答平台软件
     shortDescEn: A Q&A platform software for teams at any scales
     type: website

--- a/apps/dashy/data.yml
+++ b/apps/dashy/data.yml
@@ -7,7 +7,7 @@ additionalProperties:
     key: dashy
     name: Dashy
     tags:
-        - WebSite
+        - Website
     shortDescZh: 专为您打造的可自行托管的个人仪表板
     shortDescEn: A self-hostable personal dashboard built for you
     type: website

--- a/apps/discourse/data.yml
+++ b/apps/discourse/data.yml
@@ -7,7 +7,7 @@ additionalProperties:
     key: discourse
     name: Discourse
     tags:
-        - WebSite
+        - Website
     shortDescZh: 社区讨论的平台。免费、开放、简单。
     shortDescEn: A platform for community discussion. Free, open, simple.
     type: website

--- a/apps/discuz/data.yml
+++ b/apps/discuz/data.yml
@@ -7,7 +7,7 @@ additionalProperties:
     key: discuz
     name: Discuz!
     tags:
-        - WebSite
+        - Website
     shortDescZh: 开源社交建站系统
     shortDescEn: Open Source Social Building System
     type: website

--- a/apps/emlog/data.yml
+++ b/apps/emlog/data.yml
@@ -7,7 +7,7 @@ additionalProperties:
     key: emlog
     name: emlog
     tags:
-        - WebSite
+        - Website
     shortDescZh: 轻量级开源博客及建站系统
     shortDescEn: Lightweight open source blogging and site building system
     type: website

--- a/apps/flarum/data.yml
+++ b/apps/flarum/data.yml
@@ -7,7 +7,7 @@ additionalProperties:
     key: flarum
     name: Flarum
     tags:
-        - WebSite
+        - Website
     shortDescZh: 用于构建优秀社区的简单论坛软件
     shortDescEn: Simple forum software for building great communities
     type: website

--- a/apps/halo/data.yml
+++ b/apps/halo/data.yml
@@ -7,7 +7,7 @@ additionalProperties:
     key: halo
     name: Halo
     tags:
-        - WebSite
+        - Website
     shortDescZh: 强大易用的开源建站工具
     shortDescEn: Powerful and easy-to-use open source website builder
     type: website

--- a/apps/mblog/data.yml
+++ b/apps/mblog/data.yml
@@ -7,7 +7,7 @@ additionalProperties:
   key: mblog
   name: MBlog
   tags:
-    - WebSite
+    - Website
   shortDescZh: 开源自部署的个人微博
   shortDescEn: Open source self hosted personal micro blog platform
   type: website

--- a/apps/typecho/data.yml
+++ b/apps/typecho/data.yml
@@ -7,7 +7,7 @@ additionalProperties:
     key: typecho
     name: Typecho
     tags:
-        - WebSite
+        - Website
     shortDescZh: 基于 PHP 的博客软件
     shortDescEn: A PHP Blogging Platform. Simple and Powerful
     type: website

--- a/apps/wikijs/data.yml
+++ b/apps/wikijs/data.yml
@@ -7,7 +7,7 @@ additionalProperties:
     key: wikijs
     name: Wiki.js
     tags:
-        - WebSite
+        - Website
     shortDescZh: 基于 Node.js 构建的现代而强大的 Wiki 应用程序
     shortDescEn: A modern and powerful wiki app built on Node.js
     type: website

--- a/apps/wordpress/data.yml
+++ b/apps/wordpress/data.yml
@@ -7,7 +7,7 @@ additionalProperties:
     key: wordpress
     name: WordPress
     tags:
-        - WebSite
+        - Website
     shortDescZh: 著名的开源博客软件和 CMS 系统
     shortDescEn: Open source blogging software and content management system
     type: website

--- a/data.yaml
+++ b/data.yaml
@@ -2,7 +2,7 @@ name: 1Panel
 title: 新一代的 Linux 服务器运维管理面板
 additionalProperties:
   tags:
-    - key: WebSite
+    - key: Website
       name: 建站
       sort: 1
     - key: Database


### PR DESCRIPTION
This PR corrects the typo of [Website](https://en.wikipedia.org/wiki/Website).

Please note the `WebSite` is as the key of tag and as the English name of tag, so I'm not sure what impacts will be introduced. Please let me know if I miss something.

![image](https://github.com/user-attachments/assets/748b37b3-7bf8-4e7f-b88d-116bdc538cca)

```release-note
None
```
