### PR TITLE
fix: run custom script with eval

### DIFF
--- a/apps/node/12.22.12/run.sh
+++ b/apps/node/12.22.12/run.sh
@@ -21,7 +21,7 @@ fi
 
 
 if [[ "$CUSTOM_SCRIPT" -eq "1" ]]; then
-  $EXEC_SCRIPT
+  eval $EXEC_SCRIPT
 else
   if [[ "$PACKAGE_MANAGER" == "npm" ]]; then
       npm run $EXEC_SCRIPT

--- a/apps/node/18.20.3/run.sh
+++ b/apps/node/18.20.3/run.sh
@@ -25,7 +25,7 @@ fi
 
 
 if [[ "$CUSTOM_SCRIPT" -eq "1" ]]; then
-  $EXEC_SCRIPT
+  eval $EXEC_SCRIPT
 else
   if [[ "$PACKAGE_MANAGER" == "npm" ]]; then
       npm run $EXEC_SCRIPT

--- a/apps/node/20.14.0/run.sh
+++ b/apps/node/20.14.0/run.sh
@@ -25,7 +25,7 @@ fi
 
 
 if [[ "$CUSTOM_SCRIPT" -eq "1" ]]; then
-  $EXEC_SCRIPT
+  eval $EXEC_SCRIPT
 else
   if [[ "$PACKAGE_MANAGER" == "npm" ]]; then
       npm run $EXEC_SCRIPT

--- a/apps/node/21.7.3/run.sh
+++ b/apps/node/21.7.3/run.sh
@@ -25,7 +25,7 @@ fi
 
 
 if [[ "$CUSTOM_SCRIPT" -eq "1" ]]; then
-  $EXEC_SCRIPT
+  eval $EXEC_SCRIPT
 else
   if [[ "$PACKAGE_MANAGER" == "npm" ]]; then
       npm run $EXEC_SCRIPT

--- a/apps/node/22.2.0/run.sh
+++ b/apps/node/22.2.0/run.sh
@@ -25,7 +25,7 @@ fi
 
 
 if [[ "$CUSTOM_SCRIPT" -eq "1" ]]; then
-  $EXEC_SCRIPT
+  eval $EXEC_SCRIPT
 else
   if [[ "$PACKAGE_MANAGER" == "npm" ]]; then
       npm run $EXEC_SCRIPT


### PR DESCRIPTION
Using `eval` for custom script, in order to support multiple command in it, like `npm install && npm run build && npm run start`.