### PR TITLE
fix: update palworld and palworld-server-tool settins

### DIFF
--- a/apps/palworld-server-tool/0.9.5/data.yml
+++ b/apps/palworld-server-tool/0.9.5/data.yml
@@ -8,27 +8,79 @@ additionalProperties:
       required: true
       rule: paramPort
       type: number
-    - default: '127.0.0.1:25575'
+    - default: 'WEB_PASSWORD'
+      edit: true
+      envKey: WEB_PASSWORD
+      labelEn: WEB Password
+      labelZh: Web 界面的管理员模式密码
+      required: true
+      type: text
+    - default: '60'
+      edit: true
+      envKey: TASK_SYNC_INTERVAL
+      labelEn: Sync interval
+      labelZh: 请求服务器同步玩家在线数据的间隔
+      required: true
+      type: number
+    - default: 'false'
+      edit: true
+      envKey: TASK_PLAYER_LOGGING
+      labelEn: Enable players login/logout message
+      labelZh: 玩家进入/离开服务器是否通知
+      required: true
+      type: select
+      values:
+        - label: 是
+          value: "true"
+        - label: 否
+          value: "false"
+    - default: '玩家 {username} 加入服务器!\n当前在线人数: {online_num}'
+      edit: true
+      envKey: TASK_PLAYER_LOGIN_MESSAGE
+      labelEn: Login message
+      labelZh: 玩家进入服务器消息
+      required: true
+      type: text
+    - default: '玩家 {username} 离开服务器!\n当前在线人数: {online_num}'
+      edit: true
+      envKey: TASK_PLAYER_LOGOUT_MESSAGE
+      labelEn: Logout message
+      labelZh: 玩家离开服务器消息
+      required: true
+      type: text
+    - default: '<palworld容器名或ip>:25575'
       edit: true
       envKey: RCON_ADDRESS
       labelEn: RCON Address
       labelZh: RCON地址
       required: true
       type: text
-    - default: 'RCON_PASSWORD'
+    - default: 'http://<palworld容器名或ip>:8212'
+      edit: true
+      envKey: REST_ADDRESS
+      labelEn: REST API Address
+      labelZh: REST API地址
+      required: true
+      type: text
+    - default: 'ADMIN_PASSWORD'
       edit: true
       envKey: RCON_PASSWORD
       labelEn: RCON Password
-      labelZh: RCON密码
+      labelZh: 服务器配置文件中的 AdminPassword
       required: true
       type: text
-    - default: 'WEB_PASSWORD'
+    - default: 'false'
       edit: true
-      envKey: WEB_PASSWORD
-      labelEn: WEB Password
-      labelZh: WEB密码
+      envKey: RCON_USE_BASE64
+      labelEn: Enable PalGuard Base64 RCON
+      labelZh: 是否开启PalGuard的Base64 RCON
       required: true
-      type: text
+      type: select
+      values:
+        - label: 是
+          value: "true"
+        - label: 否
+          value: "false"
     - default: '600'
       edit: true
       envKey: SAVE_SYNC_INTERVAL
@@ -36,10 +88,22 @@ additionalProperties:
       labelZh: 存档同步间隔
       required: true
       type: number
-    - default: '示例：./data/Pal/Saved/SaveGames/0/5633F58B91BB4CFDAE555321CA7E6C8E'
+    - default: '14400'
       edit: true
-      envKey: PANEL_APP_PATH
-      labelEn: Save Path (starts with ./data)
-      labelZh: 存档路径 (以 ./data 开头)
+      envKey: SAVE_BACKUP_INTERVAL
+      labelEn: Save Backup Interval
+      labelZh: 存档备份间隔(0不备份)
       required: true
-      type: text
+      type: number
+    - default: 'false'
+      edit: true
+      envKey: MANAGE_KICK_NON_WHITELIST
+      labelEn: Automatically kick non-whitelisted players
+      labelZh: 非白名单玩家自动踢出
+      required: true
+      type: select
+      values:
+        - label: 是
+          value: "true"
+        - label: 否
+          value: "false"

--- a/apps/palworld-server-tool/0.9.5/docker-compose.yml
+++ b/apps/palworld-server-tool/0.9.5/docker-compose.yml
@@ -8,14 +8,23 @@ services:
     ports:
       - ${PANEL_APP_PORT_HTTP}:8080
     volumes:
-      - ${PANEL_APP_PATH}:/game
+      - /opt/1panel/apps/palworld/palworld/data/Pal/Saved:/game
     environment:
       - WEB__PASSWORD=${WEB_PASSWORD}
+      - TASK__SYNC_INTERVAL=${TASK_SYNC_INTERVAL}
+      - TASK__PLAYER_LOGGING=${TASK_PLAYER_LOGGING}
+      - TASK__PLAYER_LOGIN_MESSAGE=${TASK_PLAYER_LOGIN_MESSAGE}
+      - TASK__PLAYER_LOGOUT_MESSAGE=${TASK_PLAYER_LOGOUT_MESSAGE}
       - RCON__ADDRESS=${RCON_ADDRESS}
       - RCON__PASSWORD=${RCON_PASSWORD}
+      - RCON__USE_BASE64=${RCON_USE_BASE64}
+      - REST__ADDRESS=${REST_ADDRESS}
+      - REST__PASSWORD=${RCON_PASSWORD}
       - SAVE__SYNC_INTERVAL=${SAVE_SYNC_INTERVAL}
+      - SAVE__BACKUP_INTERVAL=${SAVE_BACKUP_INTERVAL}
+      - MANAGE__KICK_NON_WHITELIST=${MANAGE_KICK_NON_WHITELIST}
       - SAVE__DECODE_PATH=/app/sav_cli
-      - SAVE__PATH=/game/Level.sav
+      - SAVE__PATH=/game
     labels:  
       createdBy: "Apps"
 networks:  

--- a/apps/palworld/1.2.1/data.yml
+++ b/apps/palworld/1.2.1/data.yml
@@ -1,5 +1,17 @@
 additionalProperties:
     formFields:
+        - default: 'false'
+          edit: true
+          envKey: DISABLE_GENERATE_SETTINGS
+          labelEn: Disable generate settings
+          labelZh: 禁用自动生成配置文件
+          required: true
+          type: select
+          values:
+            - label: 是
+              value: "true"
+            - label: 否
+              value: "false"
         - default: 8211
           edit: true
           envKey: PANEL_APP_PORT_HTTP

--- a/apps/palworld/1.2.1/docker-compose.yml
+++ b/apps/palworld/1.2.1/docker-compose.yml
@@ -5,14 +5,16 @@ services:
     networks:
       - 1panel-network
     ports:
-      - ${PANEL_APP_PORT_HTTP}:${PANEL_APP_PORT_HTTP}/udp
-      - ${PANEL_APP_PORT_RCON}:${PANEL_APP_PORT_RCON}/tcp
-      - ${PANEL_APP_PORT_QUERY}:${PANEL_APP_PORT_QUERY}/udp
+      - ${PANEL_APP_PORT_HTTP}:8211/udp
+      - ${PANEL_APP_PORT_RCON}:25575/tcp
+      - 8212:8212/tcp
+      - ${PANEL_APP_PORT_QUERY}:27015/udp
     volumes:
       - ./data:/palworld/
     environment:
       - PUID=1000
       - PGID=1000
+      - DISABLE_GENERATE_SETTINGS=${DISABLE_GENERATE_SETTINGS}
       - PORT=${PANEL_APP_PORT_HTTP}
       - PLAYERS=${MAX_PLAYERS}
       - MULTITHREADING=${MULTITHREAD_SWITCH}

--- a/apps/palworld/data.yml
+++ b/apps/palworld/data.yml
@@ -14,6 +14,6 @@ additionalProperties:
     crossVersionUpdate: true
     limit: 0
     recommend: 0
-    website: https://hub.docker.com/r/kagurazakanyaa/palworld
-    github: https://github.com/KagurazakaNyaa/palworld-docker
-    document: https://github.com/KagurazakaNyaa/palworld-docker
+    website: https://hub.docker.com/r/thijsvanloef/palworld-server-docker
+    github: https://github.com/thijsvanloef/palworld-server-docker
+    document: https://palworld-server-docker.loef.dev/


### PR DESCRIPTION
1.Adjust the default version 1.2.1 documentation link on the Palworld installation instructions page to correspond to the appropriate mirror link. 
2.Update the Palworld docker-compose file to include port mapping for the new REST API feature and environment variables for the manual configuration file modification feature. 
3.Update the Palworld Server Tool's docker-compose file to include new features from the latest version.

1. 将palworld安装说明页面的默认版本1.2.1对应的文档链接调整为对应镜像的链接
2. 修改palworld的docker-compose文件和data配置文件，加入新功能rest api的端口映射和手动修改配置文件功能的环境变量
3. 修改palworld-server-tool的docker-compose文件和data配置文件，加入最近版本的新功能