### PR TITLE
fix: update Palworld and Palworld Server Tool settings

### DIFF
--- a/apps/palworld-server-tool/0.9.6/data.yml
+++ b/apps/palworld-server-tool/0.9.6/data.yml
@@ -8,27 +8,79 @@ additionalProperties:
       required: true
       rule: paramPort
       type: number
-    - default: '127.0.0.1:25575'
+    - default: 'WEB_PASSWORD'
+      edit: true
+      envKey: WEB_PASSWORD
+      labelEn: WEB Password
+      labelZh: Web 界面的管理员模式密码
+      required: true
+      type: text
+    - default: '60'
+      edit: true
+      envKey: TASK_SYNC_INTERVAL
+      labelEn: Sync interval
+      labelZh: 请求服务器同步玩家在线数据的间隔
+      required: true
+      type: number
+    - default: 'false'
+      edit: true
+      envKey: TASK_PLAYER_LOGGING
+      labelEn: Enable players login/logout message
+      labelZh: 玩家进入/离开服务器是否通知
+      required: true
+      type: select
+      values:
+        - label: "true"
+          value: "true"
+        - label: "false
+          value: "false"
+    - default: '玩家 {username} 加入服务器!\n当前在线人数: {online_num}'
+      edit: true
+      envKey: TASK_PLAYER_LOGIN_MESSAGE
+      labelEn: Login message
+      labelZh: 玩家进入服务器消息
+      required: true
+      type: text
+    - default: '玩家 {username} 离开服务器!\n当前在线人数: {online_num}'
+      edit: true
+      envKey: TASK_PLAYER_LOGOUT_MESSAGE
+      labelEn: Logout message
+      labelZh: 玩家离开服务器消息
+      required: true
+      type: text
+    - default: '<palworld容器名或ip>:25575'
       edit: true
       envKey: RCON_ADDRESS
       labelEn: RCON Address
       labelZh: RCON地址
       required: true
       type: text
-    - default: 'RCON_PASSWORD'
+    - default: 'http://<palworld容器名或ip>:8212'
       edit: true
-      envKey: RCON_PASSWORD
-      labelEn: RCON Password
-      labelZh: RCON密码
+      envKey: REST_ADDRESS
+      labelEn: REST API Address
+      labelZh: REST API地址
       required: true
       type: text
-    - default: 'WEB_PASSWORD'
+    - default: 'ADMIN_PASSWORD'
       edit: true
-      envKey: WEB_PASSWORD
-      labelEn: WEB Password
-      labelZh: WEB密码
+      envKey: ADMIN_PASSWORD
+      labelEn: ADMIN Password
+      labelZh: 服务器配置文件中的 AdminPassword
       required: true
       type: text
+    - default: 'false'
+      edit: true
+      envKey: RCON_USE_BASE64
+      labelEn: Enable PalGuard Base64 RCON
+      labelZh: 是否开启PalGuard的Base64 RCON
+      required: true
+      type: select
+      values:
+        - label: true
+          value: "true"
+        - label: false
+          value: "false"
     - default: '600'
       edit: true
       envKey: SAVE_SYNC_INTERVAL
@@ -36,10 +88,22 @@ additionalProperties:
       labelZh: 存档同步间隔
       required: true
       type: number
-    - default: '示例：./data/Pal/Saved/SaveGames/0/5633F58B91BB4CFDAE555321CA7E6C8E'
+    - default: '0'
       edit: true
-      envKey: PANEL_APP_PATH
-      labelEn: Save Path (starts with ./data)
-      labelZh: 存档路径 (以 ./data 开头)
+      envKey: SAVE_BACKUP_INTERVAL
+      labelEn: Save Backup Interval
+      labelZh: 存档备份间隔
       required: true
-      type: text
+      type: number
+    - default: 'false'
+      edit: true
+      envKey: MANAGE_KICK_NON_WHITELIST
+      labelEn: Automatically kick non-whitelisted players
+      labelZh: 非白名单玩家自动踢出
+      required: true
+      type: select
+      values:
+        - label: true
+          value: "true"
+        - label: false
+          value: "false"

--- a/apps/palworld-server-tool/0.9.6/data.yml
+++ b/apps/palworld-server-tool/0.9.6/data.yml
@@ -32,21 +32,21 @@ additionalProperties:
       values:
         - label: "true"
           value: "true"
-        - label: "false
+        - label: "false"
           value: "false"
     - default: '玩家 {username} 加入服务器!\n当前在线人数: {online_num}'
       edit: true
       envKey: TASK_PLAYER_LOGIN_MESSAGE
       labelEn: Login message
       labelZh: 玩家进入服务器消息
-      required: true
+      required: false
       type: text
     - default: '玩家 {username} 离开服务器!\n当前在线人数: {online_num}'
       edit: true
       envKey: TASK_PLAYER_LOGOUT_MESSAGE
       labelEn: Logout message
       labelZh: 玩家离开服务器消息
-      required: true
+      required: false
       type: text
     - default: '<palworld容器名或ip>:25575'
       edit: true
@@ -77,10 +77,17 @@ additionalProperties:
       required: true
       type: select
       values:
-        - label: true
+        - label: "true"
           value: "true"
-        - label: false
+        - label: "false"
           value: "false"
+    - default: '/opt/1panel/apps/palworld/palworld/data/Pal/Saved'
+      edit: true
+      envKey: PALWORLD_SAVE_PATH
+      labelEn: Palworld External Save Path
+      labelZh: 帕鲁服务器外部存档路径
+      required: true
+      type: text
     - default: '600'
       edit: true
       envKey: SAVE_SYNC_INTERVAL
@@ -103,7 +110,7 @@ additionalProperties:
       required: true
       type: select
       values:
-        - label: true
+        - label: "true"
           value: "true"
-        - label: false
+        - label: "false"
           value: "false"

--- a/apps/palworld-server-tool/0.9.6/docker-compose.yml
+++ b/apps/palworld-server-tool/0.9.6/docker-compose.yml
@@ -8,16 +8,25 @@ services:
     ports:
       - ${PANEL_APP_PORT_HTTP}:8080
     volumes:
-      - ${PANEL_APP_PATH}:/game
+      - /opt/1panel/apps/palworld/palworld/data/Pal/Saved:/game
     environment:
       - WEB__PASSWORD=${WEB_PASSWORD}
+      - TASK__SYNC_INTERVAL=${TASK_SYNC_INTERVAL}
+      - TASK__PLAYER_LOGGING=${TASK_PLAYER_LOGGING}
+      - TASK__PLAYER_LOGIN_MESSAGE=${TASK_PLAYER_LOGIN_MESSAGE}
+      - TASK__PLAYER_LOGOUT_MESSAGE=${TASK_PLAYER_LOGOUT_MESSAGE}
       - RCON__ADDRESS=${RCON_ADDRESS}
-      - RCON__PASSWORD=${RCON_PASSWORD}
+      - RCON__PASSWORD=${ADMIN_PASSWORD}
+      - RCON__USE_BASE64=${RCON_USE_BASE64}
+      - REST__ADDRESS=${REST_ADDRESS}
+      - REST__PASSWORD=${ADMIN_PASSWORD}
       - SAVE__SYNC_INTERVAL=${SAVE_SYNC_INTERVAL}
+      - SAVE__BACKUP_INTERVAL=${SAVE_BACKUP_INTERVAL}
+      - MANAGE__KICK_NON_WHITELIST=${MANAGE_KICK_NON_WHITELIST}
       - SAVE__DECODE_PATH=/app/sav_cli
-      - SAVE__PATH=/game/Level.sav
-    labels:  
+      - SAVE__PATH=/game
+    labels:
       createdBy: "Apps"
-networks:  
-  1panel-network:  
+networks:
+  1panel-network:
     external: true

--- a/apps/palworld-server-tool/0.9.6/docker-compose.yml
+++ b/apps/palworld-server-tool/0.9.6/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - ${PANEL_APP_PORT_HTTP}:8080
     volumes:
-      - /opt/1panel/apps/palworld/palworld/data/Pal/Saved:/game
+      - ${PALWORLD_SAVE_PATH}:/app/save
     environment:
       - WEB__PASSWORD=${WEB_PASSWORD}
       - TASK__SYNC_INTERVAL=${TASK_SYNC_INTERVAL}
@@ -24,7 +24,7 @@ services:
       - SAVE__BACKUP_INTERVAL=${SAVE_BACKUP_INTERVAL}
       - MANAGE__KICK_NON_WHITELIST=${MANAGE_KICK_NON_WHITELIST}
       - SAVE__DECODE_PATH=/app/sav_cli
-      - SAVE__PATH=/game
+      - SAVE__PATH=/app/save
     labels:
       createdBy: "Apps"
 networks:

--- a/apps/palworld-server-tool/README.md
+++ b/apps/palworld-server-tool/README.md
@@ -18,6 +18,8 @@
 
 本工具使用 bbolt 单文件存储，将 RCON 和 Level.sav 文件的数据通过定时任务获取并保存，提供简单的可视化界面和 REST 接口和便于管理与开发。
 
+Docker部署需要配置帕鲁服务器外部存档路径，安装时的需要填写对应的帕鲁服务器的外部存档路径。
+
 请确保前提 [开启私服 RCON](https://github.com/zaigie/palworld-server-tool?tab=readme-ov-file#%E5%A6%82%E4%BD%95%E5%BC%80%E5%90%AF%E7%A7%81%E6%9C%8D-rcon)
 
 > 解析 `Level.sav` 存档的任务需要在短时间（<20s）耗费一定的系统内存（1GB~3GB），这部分内存会在执行完解析任务后释放，因此你至少需要确保你的服务器有充足的内存。若不满足可使用如下等方式

--- a/apps/palworld-server-tool/README_en.md
+++ b/apps/palworld-server-tool/README_en.md
@@ -20,6 +20,8 @@ This tool uses **bbolt** single-file storage to periodically fetch and store dat
 
 It provides a simple visual interface and REST API, making management and development easier.
 
+When deploying with Docker, you need to configure the external save path for the Palworld server. During installation, you must provide the corresponding external save path for the Palworld server.
+
 Ensure that private server RCON is enabled by following the instructions in the [official guide](https://github.com/zaigie/palworld-server-tool?tab=readme-ov-file#%E5%A6%82%E4%BD%95%E5%BC%80%E5%90%AF%E7%A7%81%E6%9C%8D-rcon).
 
 ---

--- a/apps/palworld/1.2.2/data.yml
+++ b/apps/palworld/1.2.2/data.yml
@@ -67,15 +67,15 @@ additionalProperties:
         - default: ''
           edit: true
           envKey: PUBLIC_IP
-          labelEn: PUBLIC IP (If not specified, it will be detected automatically)
-          labelZh: 服务器 IP (留空自动检测)
+          labelEn: Community server IP (If not specified, it will be detected automatically)
+          labelZh: 社区服务器 IP (留空自动检测)
           required: false
           type: text
         - default: ''
           edit: true
           envKey: PUBLIC_PORT
-          labelEn: PUBLIC PORT (If not specified, it will be detected automatically)
-          labelZh: 服务器端口 (留空自动检测)
+          labelEn: Community server PORT (If not specified, it will be detected automatically)
+          labelZh: 社区服务器端口 (留空自动检测)
           required: false
           rule: paramPort
           type: text
@@ -135,17 +135,15 @@ additionalProperties:
           labelEn: Admin password
           labelZh: 管理员密码
           random: true
-          required: false
-          rule: paramComplexity
-          type: password
-        - default: ''
+          required: true
+          type: text
+        - default: palworld
           edit: true
           envKey: SERVER_PASSWORD
           labelEn: Server password
           labelZh: 服务器密码
-          required: false
-          rule: paramComplexity
-          type: password
+          required: true
+          type: text
         - default: 'true'
           edit: true
           envKey: RCON_SWITCH

--- a/apps/palworld/1.2.2/data.yml
+++ b/apps/palworld/1.2.2/data.yml
@@ -16,6 +16,14 @@ additionalProperties:
           required: true
           rule: paramPort
           type: number
+        - default: 8212
+          edit: true
+          envKey: PANEL_APP_PORT_REST
+          labelEn: REST API Port
+          labelZh: REST API 端口
+          required: true
+          rule: paramPort
+          type: number
         - default: 27015
           edit: true
           envKey: PANEL_APP_PORT_QUERY
@@ -38,14 +46,24 @@ additionalProperties:
           labelEn: Improves performance in multi-threaded CPU environments (true / false)
           labelZh: 是否启用 CPU 多线程优化 (true / false)
           required: true
-          type: text
+          type: select
+          values:
+            - label: "true"
+              value: "true"
+            - label: "false"
+              value: "false"
         - default: 'false'
           edit: true
           envKey: PUBLIC_SWITCH
           labelEn: Setup server as a community server (true / false)
           labelZh: 是否将服务器设置为社区服务器 (true / false)
           required: true
-          type: text
+          type: select
+          values:
+            - label: "true"
+              value: "true"
+            - label: "false"
+              value: "false"
         - default: ''
           edit: true
           envKey: PUBLIC_IP
@@ -62,18 +80,54 @@ additionalProperties:
           rule: paramPort
           type: text
         - default: 'true'
-          disabled: true
+          edit: true
           envKey: UPDATE_SWITCH
           labelEn: Whether the server should be update each time start (true / false)
           labelZh: 是否每次启动都更新服务器 (true / false)
           required: true
-          type: text
+          type: select
+          values:
+            - label: "true"
+              value: "true"
+            - label: "false"
+              value: "false"
+        - default: 'false'
+          edit: true
+          envKey: ENABLE_PLAYER_LOGGING
+          labelEn: Enable players login/logout message (true / false)
+          labelZh: 玩家进入/离开服务器是否通知 (true / false)
+          required: true
+          type: select
+          values:
+            - label: "true"
+              value: "true"
+            - label: "false"
+              value: "false"
+        - default: 'false'
+          edit: true
+          envKey: DISABLE_GENERATE_SETTINGS
+          labelEn: Disable auto-generated configuration files (affects the settings below)
+          labelZh: 禁用自动生成配置文件(会影响下方配置项生效)
+          required: true
+          type: select
+          values:
+            - label: "true"
+              value: "true"
+            - label: "false"
+              value: "false"
         - default: 'Default Palworld Server'
           edit: true
           envKey: SERVER_NAME
           labelEn: Server name
           labelZh: 服务器名
           required: true
+          type: text
+        - default: ''
+          edit: true
+          envKey: SERVER_DESCRIPTION
+          labelEn: Server description
+          labelZh: 服务器描述
+          required: false
           type: text
         - default: palworld
           edit: true
@@ -92,10 +146,27 @@ additionalProperties:
           required: false
           rule: paramComplexity
           type: password
-        - default: 'false'
+        - default: 'true'
           edit: true
           envKey: RCON_SWITCH
           labelEn: Enable RCON (true / false)
           labelZh: 是否启用 RCON (true / false)
           required: true
-          type: text
+          type: select
+          values:
+            - label: "true"
+              value: "true"
+            - label: "false"
+              value: "false"
+        - default: 'true'
+          edit: true
+          envKey: REST_SWITCH
+          labelEn: Enable REST API (true / false)
+          labelZh: 是否启用 REST API (true / false)
+          required: true
+          type: select
+          values:
+            - label: "true"
+              value: "true"
+            - label: "false"
+              value: "false"

--- a/apps/palworld/1.2.2/docker-compose.yml
+++ b/apps/palworld/1.2.2/docker-compose.yml
@@ -5,31 +5,37 @@ services:
     networks:
       - 1panel-network
     ports:
-      - ${PANEL_APP_PORT_HTTP}:${PANEL_APP_PORT_HTTP}/udp
-      - ${PANEL_APP_PORT_RCON}:${PANEL_APP_PORT_RCON}/tcp
+      - ${PANEL_APP_PORT_HTTP}:8211/udp
+      - ${PANEL_APP_PORT_RCON}:25575/tcp
+      - ${PANEL_APP_PORT_REST}:8212/tcp
       - ${PANEL_APP_PORT_QUERY}:${PANEL_APP_PORT_QUERY}/udp
     volumes:
       - ./data:/palworld/
     environment:
       - PUID=1000
       - PGID=1000
-      - PORT=${PANEL_APP_PORT_HTTP}
+      - DISABLE_GENERATE_SETTINGS=${DISABLE_GENERATE_SETTINGS}
+      - PORT=8211
       - PLAYERS=${MAX_PLAYERS}
       - MULTITHREADING=${MULTITHREAD_SWITCH}
       - COMMUNITY=${PUBLIC_SWITCH}
       - PUBLIC_IP=${PUBLIC_IP}
       - PUBLIC_PORT=${PUBLIC_PORT}
       - UPDATE_ON_BOOT=${UPDATE_SWITCH}
+      - ENABLE_PLAYER_LOGGING=${ENABLE_PLAYER_LOGGING}
       - SERVER_NAME=${SERVER_NAME}
+      - SERVER_DESCRIPTION=${SERVER_DESCRIPTION}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD}
       - SERVER_PASSWORD=${SERVER_PASSWORD}
       - RCON_ENABLED=${RCON_SWITCH}
-      - RCON_PORT=${PANEL_APP_PORT_RCON}
+      - RCON_PORT=25575
+      - REST_API_ENABLED=${REST_SWITCH}
+      - REST_API_PORT=8212
       - QUERY_PORT=${PANEL_APP_PORT_QUERY}
     image: thijsvanloef/palworld-server-docker:v1.2.2
-    labels:  
+    labels:
       createdBy: "Apps"
 
-networks:  
+networks:
   1panel-network:  
     external: true

--- a/apps/palworld/README.md
+++ b/apps/palworld/README.md
@@ -3,3 +3,5 @@
 **《幻兽帕鲁》** 是 **Pocketpair** 开发的一款开放世界生存制作游戏，游戏于 2023 年 11 月 02 日至 11 月 05 日进行了封闭网络测试，于 2024 年 01 月 18 日发行抢先体验版本。
 
 游戏中，玩家可以在广阔的世界中收集神奇的生物“帕鲁”，派他们进行战斗、建造、做农活，工业生产等。
+
+选择版本时，latest版本镜像来源是KagurazakaNyaa/palworld-docker，数字版本镜像来源是thijsvanloef/palworld-server-docker。

--- a/apps/palworld/data.yml
+++ b/apps/palworld/data.yml
@@ -14,6 +14,6 @@ additionalProperties:
     crossVersionUpdate: true
     limit: 0
     recommend: 0
-    website: https://hub.docker.com/r/kagurazakanyaa/palworld
-    github: https://github.com/KagurazakaNyaa/palworld-docker
-    document: https://github.com/KagurazakaNyaa/palworld-docker
+    website: https://hub.docker.com/r/thijsvanloef/palworld-server-docker
+    github: https://github.com/thijsvanloef/palworld-server-docker
+    document: https://palworld-server-docker.loef.dev/


### PR DESCRIPTION
1.Adjust the default version 1.2.2 documentation link on the Palworld installation instructions page to correspond to the appropriate mirror link, with added explanations for the mirror version. 
2.Modify the Palworld docker-compose file and data configuration file to include port mapping for the new REST API feature and environment variables for the manual configuration file modification feature. Added server description configurations, and revised the port mapping logic. 
3.Update the Palworld Server Tool's docker-compose file and data configuration file to include new features from the latest version. Adjusted the save path mapping for compatibility with server.

1. 将palworld安装说明页面的默认版本1.2.2对应的文档链接调整为对应镜像的链接，增加了对镜像版本的说明。
2. 修改palworld的docker-compose文件和data配置文件，加入新功能rest api的端口映射和手动修改配置文件功能的环境变量，增加了服务器描述的配置，修改了端口映射的逻辑。
3. 修改palworld-server-tool的docker-compose文件和data配置文件，加入最近版本的新功能，修改了存档路径的映射可以直接配套服务器使用。