### PR TITLE
chore: remove JVM_OPT env for Halo

### DIFF
--- a/apps/halo/2.20.13/docker-compose.yml
+++ b/apps/halo/2.20.13/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - --spring.r2dbc.password=${PANEL_DB_USER_PASSWORD}
       - --spring.sql.init.platform=${PANEL_DB_TYPE}
       - --halo.external-url=${HALO_EXTERNAL_URL}
+    environment:
+      - JVM_OPTS=
     labels:
       createdBy: "Apps"
 networks:


### PR DESCRIPTION
Removed Halo's JVM_OPTS environment variable to allow users to control memory usage by setting the maximum memory of the container.