### PR TITLE
style: 优化mysql应用的command传递方式

### DIFF
--- a/apps/mysql/5.6.51/docker-compose.yml
+++ b/apps/mysql/5.6.51/docker-compose.yml
@@ -14,10 +14,10 @@ services:
       - ./conf/my.cnf:/etc/mysql/my.cnf
       - ./log:/var/log/mysql
     command:
-      --character-set-server=utf8mb4
-      --collation-server=utf8mb4_general_ci
-      --explicit_defaults_for_timestamp=true
-      --lower_case_table_names=1
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_general_ci
+      - --explicit_defaults_for_timestamp=true
+      - --lower_case_table_names=1
     labels:
       createdBy: "Apps"
 networks:

--- a/apps/mysql/5.7.44/docker-compose.yml
+++ b/apps/mysql/5.7.44/docker-compose.yml
@@ -16,10 +16,10 @@ services:
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
     command:
-      --character-set-server=utf8mb4
-      --collation-server=utf8mb4_general_ci
-      --explicit_defaults_for_timestamp=true
-      --lower_case_table_names=1
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_general_ci
+      - --explicit_defaults_for_timestamp=true
+      - --lower_case_table_names=1
     labels:
       createdBy: "Apps"
 networks:


### PR DESCRIPTION
避免在某些情况下被误认为是一整个参数传递，如：
![image](https://github.com/user-attachments/assets/f6673791-3135-4841-9299-a44634ca3c7c)

这些参数其实是分开的：
![image](https://github.com/user-attachments/assets/b0808c78-7d79-4b92-a199-5b5fce27c273)
