### PR TITLE
feat: Remove default HTTP proxy values and add hints

### DIFF
--- a/apps/certimate/0.3.6/data.yml
+++ b/apps/certimate/0.3.6/data.yml
@@ -8,26 +8,26 @@ additionalProperties:
           required: true
           rule: paramPort
           type: number
-        - default: http://<URL_ADDRESS>:<Port>
+        - default: ""
           edit: true
           envKey: PANEL_HTTP_PROXY
-          labelEn: HTTP_PROXY
-          labelZh: HTTP_PROXY
+          labelEn: HTTP_PROXY (e.g., http://<URL_ADDRESS>:<Port>)
+          labelZh: HTTP_PROXY (例如：http://<URL_ADDRESS>:<Port>)
           required: false
           rule: paramExtUrl
           type: text
-        - default: http://<URL_ADDRESS>:<Port>
+        - default: ""
           edit: true
           envKey: PANEL_HTTPS_PROXY
-          labelEn: HTTPS_PROXY
-          labelZh: HTTPS_PROXY
+          labelEn: HTTPS_PROXY (e.g., http://<URL_ADDRESS>:<Port>)
+          labelZh: HTTPS_PROXY (例如：http://<URL_ADDRESS>:<Port>)
           required: false
           rule: paramExtUrl
           type: text
-        - default: 172.18.0.0/16,127.0.0.1,localhost
+        - default: ""
           edit: true
           envKey: PANEL_NO_PROXY
-          labelEn: NO_PROXY
-          labelZh: NO_PROXY
+          labelEn: NO_PROXY (e.g., 172.18.0.0/16,127.0.0.1,localhost)
+          labelZh: NO_PROXY (例如：172.18.0.0/16,127.0.0.1,localhost)
           required: false
           type: text


### PR DESCRIPTION
Remove misleading default values for HTTP proxy settings and add usage hints. 
移除易误导的 HTTP 代理默认值，并添加使用提示。