### PR TITLE
feat: JumpServer supports not using the built-in Nginx service

### DIFF
--- a/apps/jumpserver/4.8.1/data.yml
+++ b/apps/jumpserver/4.8.1/data.yml
@@ -188,6 +188,27 @@ additionalProperties:
         ko: Redis 서비스 비밀번호
         zh-Hant: Redis 服務密碼
         zh: Redis 服务密码
+    - default: 'true'
+      edit: true
+      envKey: WITH_NGINX
+      labelEn: Use the built-in nginx service
+      labelZh: 使用内置的 Nginx 服务
+      label:
+        en: Use the built-in nginx service
+        ja: 組み込みの Nginx サービスを使用してください
+        ms: Gunakan perkhidmatan Nginx terbina dalam
+        pt-br: Use o serviço Nginx incorporado
+        ru: Используйте встроенный сервис Nginx
+        ko: 내장된 Nginx 서비스를 사용하세요
+        zh-hant: 使用內建的 Nginx 服務
+        zh: 使用内置的 Nginx 服务
+      required: true
+      type: select
+      values:
+        - label: "Yes, I want to use the built-in Nginx service."
+          value: "true"
+        - label: "No, I will set up the Nginx reverse proxy myself."
+          value: "false"
     - default: 8080
       edit: true
       envKey: PANEL_APP_PORT_HTTP

--- a/apps/jumpserver/4.8.1/scripts/init.sh
+++ b/apps/jumpserver/4.8.1/scripts/init.sh
@@ -19,6 +19,10 @@ if [ -f "$ENV_FILE" ]; then
   else
     echo DB_ENGINE="$ENGINE" >> "$ENV_FILE"
   fi
+
+  if [ "$(grep '^WITH_NGINX=' "$ENV_FILE" | cut -d '=' -f 2 | tr -d '"')" == "false" ]; then
+    sed -i.bak 's/${HOST_IP}:${PANEL_APP_PORT_HTTP}:80/127.0.0.1:${PANEL_APP_PORT_HTTP}:51980/g' "docker-compose.yml"
+  fi
 else
     echo ".env file not found!"
     exit 1


### PR DESCRIPTION
There are some issues when I use port 80:
 1. When using Nginx reverse proxy, it cannot obtain the correct IP address;
 2. Deploying SSL certificates is relatively complicated;
 3. It cannot coexist with the Nginx of 1Panel.