### PR TITLE
chore(deps):  Nacos 3.0+: Separate Configuration of Nacos GUI Port and API Port

### DIFF
--- a/apps/nacos/3.0.1/data.yml
+++ b/apps/nacos/3.0.1/data.yml
@@ -11,11 +11,19 @@ additionalProperties:
           value: "true"
         - label: 关闭
           value: "false"
-    - default: 8848
+    - default: 8080
       edit: true
       envKey: PANEL_APP_PORT_HTTP
-      labelEn: Nacos run port
-      labelZh: Nacos 运行端口
+      labelEn: Nacos GUI port
+      labelZh: Nacos 界面 访问端口
+      required: true
+      rule: paramPort
+      type: number
+    - default: 8848
+      edit: true
+      envKey: PANEL_APP_PORT_API_HTTP
+      labelEn: Nacos api port
+      labelZh: Nacos API端口
       required: true
       rule: paramPort
       type: number

--- a/apps/nacos/3.0.1/docker-compose.yml
+++ b/apps/nacos/3.0.1/docker-compose.yml
@@ -20,7 +20,8 @@ services:
       - ./data/logs:/home/nacos/logs
       - ./data/data:/home/nacos/data
     ports:
-      - "${PANEL_APP_PORT_HTTP}:8848"
+      - "${PANEL_APP_PORT_HTTP}:8080"
+      - "${PANEL_APP_PORT_API_HTTP}:8848"
       - "${PANEL_APP_PORT_COMMUNICATION}:9848"
     labels:  
       createdBy: "Apps"

--- a/apps/nacos/README.md
+++ b/apps/nacos/README.md
@@ -6,6 +6,13 @@
 - 用户名：`nacos`
 - 密码：`nacos`
 
+
+### 如果是nacos3.0+版本
+
+- 访问地址：`http://IP:8080/index.html`
+- 用户名：`nacos`
+- 密码：首次打开会要求初始化管理员用户nacos的密码
+
 ## 参数调优
 
 ```shell


### PR DESCRIPTION
为Nacos 3.0+版本新增独立GUI端口(8080)配置，将原运行端口(8848)明确标记为API端口
- 修改data.yml配置，新增GUI端口配置项并将原端口重命名为API端口
- 更新docker-compose.yml以映射新的GUI和API端口
- 在README.md中补充3.0+版本的访问说明

# 配置页面新增GUI端口配置
![image](https://github.com/user-attachments/assets/ace9e199-6c7c-40eb-8983-88bb7cb8ba69)


#  使用说明
![image](https://github.com/user-attachments/assets/559ad0ae-98c8-4cb7-a9bc-569bb8bfcee7)
