### PR TITLE
Modify cloudreve's deployment configuration

### DIFF
--- a/apps/cloudreve/4.0.0/data.yml
+++ b/apps/cloudreve/4.0.0/data.yml
@@ -26,7 +26,7 @@ additionalProperties:
         - label: MySQL
           value: mysql
         - label: MariaDB
-          value: mariadb
+          value: mysql
     - default: cloudreve
       envKey: PANEL_DB_NAME
       labelEn: Database

--- a/apps/cloudreve/4.0.0/docker-compose.yml
+++ b/apps/cloudreve/4.0.0/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - CR_CONF_Database.Name=${PANEL_DB_NAME}
       - CR_CONF_Database.User=${PANEL_DB_USER}
       - CR_CONF_Database.Password=${PANEL_DB_USER_PASSWORD}
-      - CR_CONF_Database.Port=5432
+      - CR_CONF_Database.Port=${PANEL_DB_PORT}
       - CR_CONF_Redis.Server=${PANEL_REDIS_HOST}:6379
       - CR_CONF_Redis.Password=${PANEL_REDIS_ROOT_PASSWORD}
     volumes:


### PR DESCRIPTION
Modify the update of cloudreve, the current setup has been personally tested and cannot complete the deployment, and the project does not directly support the Mariadb category, but using MySQL to link Mariadb is completely feasible.