### PR TITLE
fix(config): set PostgreSQL driver value to 'pgsql' for Laravel compatibility

### DIFF
--- a/apps/firefly-iii/6.2.12/data.yml
+++ b/apps/firefly-iii/6.2.12/data.yml
@@ -39,7 +39,7 @@ additionalProperties:
             - label: MySQL
               value: mysql
             - label: PostgreSQL
-              value: postgres
+              value: pgsql
         - default: firefly
           envKey: PANEL_DB_NAME
           labelEn: Database


### PR DESCRIPTION
Laravel requires the DB_CONNECTION to be 'pgsql' instead of 'postgres'.
Previously, selecting PostgreSQL would set PANEL_DB_TYPE=postgres, causing
an InvalidArgumentException ("Database connection [postgres] not configured.").

This commit updates the configuration value mapping:

- PostgreSQL: 'pgsql' (was 'postgres')

This fixes Firefly III and other Laravel-based apps database connection issues.