### PR TITLE
fix(appstore): replace deprecated bitnami Kafka image with legacy repo

### DIFF
--- a/apps/kafka/4.0.0/docker-compose.yml
+++ b/apps/kafka/4.0.0/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - 1panel-network
     ports:
       - "${PANEL_APP_PORT_HTTP}:9092"
-    image: bitnami/kafka:4.0.0
+    image: bitnamilegacy/kafka:4.0.0
     labels:
       createdBy: "Apps"
 networks:  


### PR DESCRIPTION
 Important Notice: Upcoming changes to the Bitnami Catalog
This image is part of the brownout announced at https://github.com/bitnami/containers/issues/83267⁠⁠

Beginning August 28th, 2025, Bitnami will evolve its public catalog to offer a curated set of hardened, security-focused images under the new Bitnami Secure Images initiative⁠. As part of this transition:

Bitnami will begin deprecating support for non-hardened, Debian-based software images in its free tier and will gradually remove tags from the public catalog. As a result, community users will have access to a reduced number of hardened images. These images are published only under the “latest” tag and are intended for development purposes All existing container images have been migrated from the public catalog (docker.io/bitnami) to the “Bitnami Legacy” repository (docker.io/bitnamilegacy), where they will no longer receive updates. For production workloads and long-term support, users are encouraged to adopt Bitnami Secure Images, which include hardened containers, smaller attack surfaces, CVE transparency (via VEX/KEV), SBOMs, and enterprise support. These changes aim to improve the security posture of all Bitnami users by promoting best practices for software supply chain integrity and up-to-date deployments. For more details, visit the Bitnami Secure Images announcement⁠.