### PR TITLE
fix(appstore): replaced deprecated Bitnami Kafka image with legacy repo

### DIFF
--- a/apps/kafka/4.0.0/docker-compose.yml
+++ b/apps/kafka/4.0.0/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - 1panel-network
     ports:
       - "${PANEL_APP_PORT_HTTP}:9092"
-    image: bitnami/kafka:4.0.0
+    image: bitnamilegacy/kafka:4.0.0
     labels:
       createdBy: "Apps"
 networks:  


### PR DESCRIPTION
### What this PR does
Replaces the deprecated `bitnami/kafka` image with `bitnamilegacy/kafka` 
to ensure compatibility with 1Panel App Store.

### Why this change is needed
Bitnami announced that, starting August 28th, 2025, 
non-hardened Debian-based images are deprecated and migrated to 
[docker.io/bitnamilegacy](https://hub.docker.com/r/bitnamilegacy/kafka).  
These legacy images will no longer receive updates.

Reference: [Bitnami Secure Images announcement](https://github.com/bitnami/containers/issues/83267)

### Impact
- Keeps Kafka App working in App Store
- No functional changes for users, but **no security updates** will be available for this image
- Production users should migrate to hardened Bitnami Secure Images or official Kafka images

### Release note
```release-note
Replaced deprecated Bitnami Kafka image with `bitnamilegacy/kafka`.
Users should migrate to hardened Bitnami Secure Images for production workloads.
---