### PR TITLE
🚑️ fix(openlist): fix openlist

### DIFF
--- a/apps/openlist/4.1.1/docker-compose.yml
+++ b/apps/openlist/4.1.1/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     image: ${OPENLIST_IMAGE}
     container_name: ${CONTAINER_NAME}
     restart: always
+    user: "0:0"
     networks:
       - 1panel-network
     ports:
@@ -12,8 +13,6 @@ services:
       - ./data:/opt/openlist/data
     environment:
       - TZ=${TIME_ZONE}
-      - PUID=0
-      - PGID=0
       - UMASK=022
     labels:  
       createdBy: "Apps"


### PR DESCRIPTION
修复 openlist 4.1.1 版本之后的部署方式。延用之前版本的方式会导致部署失败。

[openlist 4.1.1 官方说明](https://github.com/OpenListTeam/OpenList/releases/tag/v4.1.1)

<img width="1154" height="523" alt="image" src="https://github.com/user-attachments/assets/3f18aea4-e5d8-43ca-85ff-524032fc59c3" />
