### PR TITLE
Feat: Add some new configuration and fix node name setting

### DIFF
--- a/apps/emqx/5.10.0/data.yml
+++ b/apps/emqx/5.10.0/data.yml
@@ -85,3 +85,75 @@ additionalProperties:
           required: true
           rule: paramPort
           type: number
+        - default: emqx
+          envKey: EMQX_Dashboard_Password
+          labelEn: Dashboard Password
+          labelZh: Dashboard 密码
+          label:
+            en: Dashboard Password
+            ja: ダッシュボードのパスワード
+            ms: Kata Laluan Papan Pemuka
+            pt-br: Senha do Painel
+            ru: Пароль панели управления
+            ko: 대시보드 비밀번호
+            zh-Hant: Dashboard 密碼
+            zh: Dashboard 密码
+          random: true
+          required: true
+          rule: paramComplexity
+          type: password
+        - default: EMQX_Cookie
+          envKey: EMQX_Cookie
+          labelEn: EMQX Cookie
+          labelZh: EMQX Cookie
+          label:
+            en: EMQX Cookie
+            ja: EMQX Cookie
+            ms: EMQX Cookie
+            pt-br: EMQX Cookie
+            ru: EMQX Cookie
+            ko: EMQX Cookie
+            zh-Hant: EMQX Cookie
+            zh: EMQX Cookie
+          random: true
+          required: true
+          rule: paramCommon
+          type: password
+        - default: "both"
+          envKey: EMQX_LOG_TO
+          labelEn: Log To
+          labelZh: 日志输出目标
+          label:
+            en: Log To
+            ja: ログ出力先
+            ms: Log Kepada
+            pt-br: Enviar Log Para
+            ru: Вывод журнала
+            ko: 로그 출력 대상
+            zh-Hant: 日誌輸出目標
+            zh: 日志输出目标
+          required: true
+          type: select
+          values:
+            - label: Console
+              value: console
+            - label: File
+              value: file
+            - label: Both
+              value: both
+        - default: Asia/Shanghai
+          edit: true
+          envKey: TIME_ZONE
+          labelEn: Time zone
+          labelZh: 时区
+          label:
+            en: Time zone
+            ja: タイムゾーン
+            ms: Zon masa
+            pt-br: Fuso horário
+            ru: Часовой пояс
+            ko: 시간대
+            zh: 时区
+            zh-Hant: 時區
+          required: true
+          type: text

--- a/apps/emqx/5.10.0/docker-compose.yml
+++ b/apps/emqx/5.10.0/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   emqx:
     image: emqx/emqx:5.10.0
     container_name: ${CONTAINER_NAME}
+    hostname: 1panel.dev
     restart: always
     networks:
       - 1panel-network
@@ -13,10 +14,24 @@ services:
       - ${EMQX_PORT_8084}:8084
       - ${EMQX_PORT_8883}:8883
     volumes:
-      - ./data:/opt/emqx/data
-      - ./log:/opt/emqx/log
+      - ./data:/opt/emqx/data:rw
+      - ./log:/opt/emqx/log:rw
+      - ./plugins:/opt/emqx/plugins:rw
     environment:
-      - EMQX_NODE_NAME=emqx@${CONTAINER_NAME}
+      - EMQX_HOST=1panel.dev
+      - EMQX_NAME=${CONTAINER_NAME}
+      - EMQX_NODE__DATA_DIR=data
+      - EMQX_LOG__TO=${EMQX_LOG_TO}
+      - EMQX_NODE_COOKIE=1panel_${EMQX_Cookie}
+      - EMQX_CLUSTER__NAME=${CONTAINER_NAME} 
+      - EMQX_DASHBOARD__DEFAULT_PASSWORD=${EMQX_Dashboard_Password}
+      - TZ=${TIME_ZONE}
+    healthcheck:
+      test: ["CMD", "/opt/emqx/bin/emqx_ctl", "status"]
+      interval: 60s
+      timeout: 15s
+      retries: 3
+      start_period: 90s  
     labels:
       createdBy: "Apps"
 networks:


### PR DESCRIPTION
## Add some new configuration

1. EMQX Dashboard Default Password
2. EMQX Node Cookie
3. EMQX Cluster Name
4. EMQX Log Output
5. EMQX Plugin Mount
6. Add EMQX HealthCheck
7.  TimeZone


## Fix NodeName

EMQX employs the data/mnesia/<node_name> directory for data storage. It's crucial to choose a stable identifier, such as a Fully Qualified Domain Name (FQDN), to serve as the node name. This practice avoids data loss caused by node name changes.
`EMQX_NODE_NAME = EMQX_NAME@EMQX_HOST`