### PR TITLE
fix(rustfs): update uid for rustfs breaking changes 1.0.0-alpha.69

### DIFF
--- a/apps/rustfs/latest/scripts/init.sh
+++ b/apps/rustfs/latest/scripts/init.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 mkdir data
-chown -R 1000:1000 data
+chown -R 10001:10001 data


### PR DESCRIPTION

[1.0.0-alpha.69](https://github.com/rustfs/rustfs/releases/tag/1.0.0-alpha.69) Pre-release
⚠️ Breaking Changes / Upgrade Notes

Container Security Update: The container startup user has been changed to UID 10001 (non-root) for improved security.

Action Required: If you encounter "Permission Denied" errors after upgrading, please update the ownership of your mounted data directory to the new user.


# Example: Fix permissions for your mounted volume
chown -R 10001:10001 /data
chown -R 10001:10001  /logs