### PR TITLE
feat(uptime-kuma): 添加2.3.0版本的docker-compose和数据配置文件

### DIFF
--- a/apps/uptime-kuma/2.3.0/data.yml
+++ b/apps/uptime-kuma/2.3.0/data.yml
@@ -1,0 +1,21 @@
+additionalProperties:
+  formFields:
+    - default: 3001
+      edit: true
+      envKey: PANEL_APP_PORT_HTTP
+      labelEn: Port
+      labelZh: 端口
+      label:
+        en: Port
+        es-es: Puerto
+        ja: ポート
+        ms: Port
+        pt-br: Porta
+        ru: Порт
+        ko: 포트
+        zh-Hant: 埠
+        zh: 端口
+        tr: Bağlantı Noktası
+      required: true
+      rule: paramPort
+      type: number

--- a/apps/uptime-kuma/2.3.0/docker-compose.yml
+++ b/apps/uptime-kuma/2.3.0/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  uptime-kuma:
+    image: louislam/uptime-kuma:2.3.0
+    container_name: ${CONTAINER_NAME}
+    restart: always
+    networks:
+      - 1panel-network
+    volumes:
+      - ./data:/app/data
+    ports:
+      - ${PANEL_APP_PORT_HTTP}:3001
+    labels:
+      createdBy: "Apps"
+networks:
+  1panel-network:
+    external: true


### PR DESCRIPTION
添加Uptime Kuma 2.3.0的docker-compose配置和数据配置文件，包括端口设置和网络配置