### PR TITLE
🐛 fix(docmost): fix upgrade lost app_secret

### DIFF
--- a/apps/docmost/0.90.0/scripts/upgrade.sh
+++ b/apps/docmost/0.90.0/scripts/upgrade.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ -f ./scripts/init.sh ]; then
+  bash ./scripts/init.sh
+fi


### PR DESCRIPTION
修复 `docmost` 升级丢失 `APP_SECRET` 变量，导致应用无法正常启动的问题。

已本地测试通过，无影响。

来源：https://bbs.fit2cloud.com/t/topic/18735