### PR TITLE
fix: update frpc config

### DIFF
--- a/apps/frpc/0.69.1/data.yml
+++ b/apps/frpc/0.69.1/data.yml
@@ -130,3 +130,48 @@ additionalProperties:
         tr: Kimlik doğrulama tokenı
       required: true
       type: text
+    - default: "false"
+      envKey: ENABLE_VIRTUAL_NET
+      labelEn: Enable Virtual Network
+      labelZh: 启用虚拟网络
+      label:
+        en: Enable Virtual Network
+        zh: 启用虚拟网络
+        es-es: Habilitar red virtual
+        fa: 'فعال‌سازی شبکه مجازی'
+        zh-Hant: 啟用虛擬網絡
+        ja: 仮想ネットワークを有効にする
+        ko: 가상 네트워크 활성화
+        ms: Dayakan rangkaian maya
+        pt-br: Habilitar rede virtual
+        ru: Включить виртуальную сеть
+        tr: Sanal ağı etkinleştir
+      required: true
+      type: select
+      values:
+        - label: "开启"
+          value: "true"
+        - label: "关闭"
+          value: "false"
+    - default: "10.0.0.1/24"
+      envKey: VIRTUAL_NET_IP
+      labelEn: Virtual Network IP (CIDR)
+      labelZh: 虚拟网络IP (CIDR)（仅启用虚拟网络时生效）
+      label:
+        en: Virtual Network IP (CIDR)
+        zh: 虚拟网络IP (CIDR)（仅启用虚拟网络时生效）
+        es-es: IP de red virtual (CIDR)
+        fa: 'آدرس شبکه مجازی (CIDR)'
+        zh-Hant: 虛擬網絡IP (CIDR)（僅啟用虛擬網絡時生效）
+        ja: 仮想ネットワークIP (CIDR)
+        ko: 가상 네트워크 IP (CIDR)
+        ms: IP rangkaian maya (CIDR)
+        pt-br: IP da rede virtual (CIDR)
+        ru: IP виртуальной сети (CIDR)
+        tr: Sanal ağ IP'si (CIDR)
+      required: true
+      type: text
+
+
+
+

--- a/apps/frpc/0.69.1/data/frpc.toml
+++ b/apps/frpc/0.69.1/data/frpc.toml
@@ -1,6 +1,11 @@
 serverAddr = "0.0.0.0"
 serverPort = 7000
 
+# featureGates = { VirtualNet = true }
+
+# 配置虚拟网络接口
+# virtualNet.address = "10.10.10.10/24"
+
 user = "Frp Client"
 
 auth.method = "token"

--- a/apps/frpc/0.69.1/docker-compose.yml
+++ b/apps/frpc/0.69.1/docker-compose.yml
@@ -3,7 +3,11 @@ services:
     image: snowdreamtech/frpc:0.69.1
     container_name: ${CONTAINER_NAME}
     restart: always
+    cap_add:
+      - NET_ADMIN
     network_mode: host
+    devices:
+      - "/dev/net/tun:/dev/net/tun"
     volumes:
       - ./data:/etc/frp
     labels:

--- a/apps/frpc/0.69.1/scripts/init.sh
+++ b/apps/frpc/0.69.1/scripts/init.sh
@@ -2,6 +2,14 @@
 
 source ./.env
 
+# 确保宿主机已加载 tun 内核模块：docker-compose 将 /dev/net/tun 设备映射进容器，
+# 若宿主机不存在该设备，容器将无法创建。虚拟网络（VirtualNet）依赖此设备。
+modprobe tun >/dev/null 2>&1 || true
+if [ ! -c /dev/net/tun ]; then
+  echo "警告: /dev/net/tun 设备不存在，虚拟网络可能无法正常工作，请确认宿主机已启用 tun 内核模块"
+fi
+
+
 sed -i "s/user = \".*\"/user = \"${CLIENT_NAME}\"/" ./data/frpc.toml
 sed -i "s/serverAddr = \".*\"/serverAddr = \"${SERVER_ADDRESS}\"/" ./data/frpc.toml
 sed -i "s/serverPort = .*$/serverPort = ${SERVER_PORT}/" ./data/frpc.toml
@@ -9,3 +17,27 @@ sed -i "s/auth\.token = \".*\"/auth.token = \"${AUTH_TOKEN}\"/" ./data/frpc.toml
 sed -i "s/webServer\.port = .*$/webServer.port = ${PANEL_APP_PORT_HTTP}/" ./data/frpc.toml
 sed -i "s/webServer\.user = \".*\"/webServer.user = \"${USER_NAME}\"/" ./data/frpc.toml
 sed -i "s/webServer\.password = \".*\"/webServer.password = \"${PASSWORD}\"/" ./data/frpc.toml
+
+
+if [ "${ENABLE_VIRTUAL_NET}" = "true" ]; then
+  # 开启虚拟网络时，虚拟网络IP不能为空且必须为合法 CIDR 格式
+  if [ -z "${VIRTUAL_NET_IP}" ]; then
+    echo "错误: 已启用虚拟网络，但未填写虚拟网络IP (VIRTUAL_NET_IP)，请填写后重新安装" >&2
+    exit 1
+  fi
+  if ! echo "${VIRTUAL_NET_IP}" | grep -Eq '^([0-9]{1,3}\.){3}[0-9]{1,3}/([0-9]|[12][0-9]|3[0-2])$'; then
+    echo "错误: 虚拟网络IP格式不正确，必须为 CIDR 格式（如 10.0.0.1/24）" >&2
+    exit 1
+  fi
+  ip_part="${VIRTUAL_NET_IP%/*}"
+  IFS='.' read -r o1 o2 o3 o4 <<< "$ip_part"
+  for o in "$o1" "$o2" "$o3" "$o4"; do
+    if [ "$o" -lt 0 ] || [ "$o" -gt 255 ]; then
+      echo "错误: 虚拟网络IP地址非法，每个段必须在 0-255 之间" >&2
+      exit 1
+    fi
+  done
+
+  sed -i "s|^# featureGates = { VirtualNet = true }|featureGates = { VirtualNet = true }|" ./data/frpc.toml
+  sed -i "s|^# virtualNet.address = \".*\"|virtualNet.address = \"${VIRTUAL_NET_IP}\"|" ./data/frpc.toml
+fi


### PR DESCRIPTION
## SUMMARY

* Add two form fields in `apps/frpc/0.69.1/data.yml`:
  * `ENABLE_VIRTUAL_NET` (`select` toggle: enable / disable, default disabled) — whether to enable frpc VirtualNet feature
  * `VIRTUAL_NET_IP` (`text`, default `10.0.0.1/24`) — CIDR address for the virtual network interface
* Add the commented-out VirtualNet config block in `apps/frpc/0.69.1/data/frpc.toml`:
  * `# featureGates = { VirtualNet = true }`
  * `# virtualNet.address = "10.10.10.10/24"`
* Grant the capabilities required by VirtualNet to the frpc service in `apps/frpc/0.69.1/docker-compose.yml`:
  * `cap_add: NET_ADMIN`
  * `devices: "/dev/net/tun:/dev/net/tun"`
* Add VirtualNet handling in `apps/frpc/0.69.1/scripts/init.sh`:
  * On the host side, run `modprobe tun` (silent, failure-tolerant) and check whether the `/dev/net/tun` character device exists, warning if missing
  * When `ENABLE_VIRTUAL_NET=true`: validate that `VIRTUAL_NET_IP` is non-empty and a valid CIDR (format `IPv4/0-32` with each octet 0–255), then uncomment `featureGates` and `virtualNet.address` and write them into `frpc.toml`

## VALIDATION

* Verify the two new fields in `data.yml` render correctly in the 1Panel install / modify-parameters form (toggle + text input)
* Verify the `sed` replacements in `init.sh` correctly uncomment the VirtualNet config block when enabled
* Verify the `cap_add` and `devices` mapping syntax in `docker-compose.yml` is correct
* Verify the `modprobe tun` and `/dev/net/tun` device-check logic executes normally as root on the host

## NOTES

* `init.sh` runs on the host as root during install / rebuild; modifying parameters and saving alone does not re-run this script — a rebuild is required for the config to take effect
* VirtualNet depends on the host having the `tun` kernel module; on some minimal-kernel hosts it may need to be loaded manually
* The VirtualNet config in `data/frpc.toml` is commented out by default and is only activated by `init.sh` when the switch is enabled