### PR TITLE
新增独立Zabbix Proxy分布式监控代理应用

### DIFF
--- a/apps/zabbix-proxy/README.md
+++ b/apps/zabbix-proxy/README.md
@@ -1,0 +1,15 @@
+# Zabbix Proxy 分布式监控代理
+## 功能介绍
+独立部署Zabbix Proxy，用于多机房、跨网段分布式监控，采用**主动上报模式**，仅需Proxy单向访问Zabbix Server，内网隔离场景更安全。
+
+## 兼容说明
+1. 完美兼容1Panel应用商店一键部署的Zabbix服务端；
+2. 数据库外置独立MySQL，不与服务端共用数据库；
+3. 自动复用1panel-network全局网络，无需额外网络配置。
+
+## 环境参数说明
+1. ZBX_HOSTNAME：Proxy标识名称，Zabbix后台创建代理名称必须完全一致；
+2. ZBX_SERVER_HOST：Zabbix Server服务内网IP；
+3. PANEL_DB_HOST：存储Proxy监控数据的MySQL数据库地址；
+4. PANEL_DB_PORT：MySQL数据库端口；
+5. PANEL_DB_USER_PASSWORD：MySQL数据库root账号密码。

--- a/apps/zabbix-proxy/docker-compose.yml
+++ b/apps/zabbix-proxy/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+
+services:
+  zabbix-proxy-mysql:
+    image: zabbix/zabbix-proxy-mysql:alpine-7.0.27
+    container_name: ${CONTAINER_NAME}
+    restart: always
+    networks:
+      - 1panel-network
+    ports:
+      - "${PANEL_APP_PORT_AGENT}:10051"
+    environment:
+      - ZBX_HOSTNAME=${ZBX_HOSTNAME}
+      - ZBX_SERVER_HOST=${ZBX_SERVER_HOST}
+      - ZBX_SERVER_PORT=10051
+      - ZBX_PROXYMODE=0
+      - DB_SERVER_HOST=${PANEL_DB_HOST}
+      - DB_SERVER_PORT=${PANEL_DB_PORT}
+      - MYSQL_DATABASE=zabbix_proxy
+      - MYSQL_USER=root
+      - MYSQL_PASSWORD=${PANEL_DB_USER_PASSWORD}
+      - TZ=Asia/Shanghai
+    labels:
+      createdBy: "Apps"
+
+networks:
+  1panel-network:
+    external: true

--- a/apps/zabbix-proxy/manifest.json
+++ b/apps/zabbix-proxy/manifest.json
@@ -1,0 +1,45 @@
+{
+  "name": "zabbix-proxy",
+  "title": "Zabbix Proxy 分布式监控代理",
+  "version": "7.0.27",
+  "image": "zabbix/zabbix-proxy-mysql:alpine-7.0.27",
+  "description": "独立分布式Zabbix Proxy，分担Zabbix Server采集压力，主动模式对接1Panel内置Zabbix服务端",
+  "author": "Hu-MeiXi",
+  "category": "监控",
+  "ports": [
+    {
+      "key": "PANEL_APP_PORT_AGENT",
+      "name": "Proxy通信端口",
+      "default": "10072"
+    }
+  ],
+  "env": [
+    {
+      "key": "ZBX_HOSTNAME",
+      "name": "Proxy代理名称",
+      "default": "zabbix-proxy-01"
+    },
+    {
+      "key": "ZBX_SERVER_HOST",
+      "name": "Zabbix Server地址",
+      "default": "10.1.12.69"
+    },
+    {
+      "key": "PANEL_DB_HOST",
+      "name": "Proxy数据库地址",
+      "default": "10.1.12.38"
+    },
+    {
+      "key": "PANEL_DB_PORT",
+      "name": "数据库端口",
+      "default": "3306"
+    },
+    {
+      "key": "PANEL_DB_USER_PASSWORD",
+      "name": "数据库Root密码",
+      "default": "Password123@mysql"
+    }
+  ],
+  "network": "1panel-network",
+  "restart": "always"
+}


### PR DESCRIPTION
1. 新增独立部署Zabbix Proxy应用，兼容1Panel内置一体化Zabbix服务；
2. 采用主动上报模式，适用于异地机房、内网隔离分布式监控场景；
3. 镜像版本alpine-7.0.27，数据库外置独立MySQL存储；
4. 复用1panel-network全局网络，所有参数支持面板可视化自定义；
5. 编排格式、变量命名完全对齐官方Zabbix Server模板规范。