### PR TITLE
fix: update JumpServer log level options

### DIFF
--- a/apps/jumpserver/4.10.18/data.yml
+++ b/apps/jumpserver/4.10.18/data.yml
@@ -72,12 +72,10 @@ additionalProperties:
           value: "DEBUG"
         - label: INFO
           value: "INFO"
-        - label: WARNING
-          value: "WARNING"
+        - label: WARN
+          value: "WARN"
         - label: ERROR
           value: "ERROR"
-        - label: CRITICAL
-          value: "CRITICAL"
       label:
         en: Log level
         es-es: Nivel de registro


### PR DESCRIPTION
Fix unsupported JumpServer LOG_LEVEL options.

The JumpServer app template passes `LOG_LEVEL` directly into docker-compose:

LOG_LEVEL: ${LOG_LEVEL}

Chen reads this value and writes it directly to Spring logging config. Spring/Logback accepts `WARN`, but not `WARNING`; `CRITICAL` is also not a supported level in this path.

This updates the template options to use `WARN` and removes `CRITICAL`.