### PR TITLE
feat: 更新 mliev-dwz 镜像路径 (#8795)

### DIFF
--- a/apps/mliev-dwz/2.23.0/docker-compose.yml
+++ b/apps/mliev-dwz/2.23.0/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   dwz-server:
     container_name: ${CONTAINER_NAME}
-    image: docker.cnb.cool/mliev/open/dwz-server:v2.23.0
+    image: docker.cnb.cool/mliev/dwz/dwz-server:v2.23.0
     restart: always
     networks:
       - 1panel-network


### PR DESCRIPTION
将 dwz-server 镜像路径从 `docker.cnb.cool/mliev/open/dwz-server` 更新为 `docker.cnb.cool/mliev/dwz/dwz-server`