### PR TITLE
feat(vllm): add Ascend 910B (openEuler) version with Qwen3.6-35B-A3B launch template

### DIFF
--- a/apps/vllm/README.md
+++ b/apps/vllm/README.md
@@ -25,6 +25,15 @@
 4. Atlas 300I DUO / Ascend 310P 不建议使用 `triton` 或 `triton-ascend`。如果遇到 `module 'triton' has no attribute 'language'`，请检查容器内是否残留相关包并卸载。
 5. 推荐优先使用 Qwen3 W8A8SC-310 适配模型；Qwen3.5/Qwen3.6 属于预览支持，需要按模型说明调整启动参数。
 
+### Ascend 910B (openEuler) 版本
+
+1. 面向 Atlas 800 / Atlas 300T Pro 等 910B 系列 NPU 服务器，镜像为 `vllm-ascend:v0.20.2rc1-openeuler`。
+2. 宿主机需已安装 Ascend 驱动/CANN，`npu-smi info` 能正常识别 910B 设备。
+3. Compose 使用 `ipc: host`、`privileged: true`、`seccomp=unconfined`，并显式挂载 `/dev/davinci0`–`/dev/davinci7` 及管理设备。
+4. 默认启动模板为 Qwen3.6-35B-A3B 双卡（`ASCEND_RT_VISIBLE_DEVICES=0,1`）最佳实践命令，含 tensor-parallel-size 2、expert-parallel、qwen3_5_mtp 投机解码、FULL_DECODE_ONLY cudagraph、enable_cpu_binding 等参数。
+5. `MODEL_DIR` 默认 `/data01/models`，`MODEL_NAME` 默认 `Qwen3.6-35B-A3B`；容器内工作目录为 `/workspace`。
+6. `HCCL_BUFFSIZE` 设为 1024（910B 推荐），如遇内存不足可适当调低。
+
 ## 产品介绍
 
 **vLLM** is a fast and easy-to-use library for LLM inference and serving.

--- a/apps/vllm/README_en.md
+++ b/apps/vllm/README_en.md
@@ -25,6 +25,15 @@
 4. Atlas 300I DUO / Ascend 310P should not depend on `triton` or `triton-ascend`. If `module 'triton' has no attribute 'language'` appears, check and uninstall residual packages in the container.
 5. Prefer Qwen3 W8A8SC-310 adapted models for stable use. Qwen3.5/Qwen3.6 support is preview-level and may need model-specific launch arguments.
 
+### Ascend 910B (openEuler) version
+
+1. Targets Atlas 800 / Atlas 300T Pro and other 910B-series NPU servers. Image: `vllm-ascend:v0.20.2rc1-openeuler`.
+2. The host must have the Ascend driver/CANN installed, and `npu-smi info` must correctly identify the 910B devices.
+3. The Compose file uses `ipc: host`, `privileged: true`, `seccomp=unconfined`, and explicitly mounts `/dev/davinci0`–`/dev/davinci7` plus management devices.
+4. The default launch template is the Qwen3.6-35B-A3B dual-card (`ASCEND_RT_VISIBLE_DEVICES=0,1`) best-practice command, including tensor-parallel-size 2, expert-parallel, qwen3_5_mtp speculative decoding, FULL_DECODE_ONLY cudagraph, and enable_cpu_binding.
+5. `MODEL_DIR` defaults to `/data01/models`, `MODEL_NAME` defaults to `Qwen3.6-35B-A3B`; the in-container working directory is `/workspace`.
+6. `HCCL_BUFFSIZE` is set to 1024 (recommended for 910B); lower it if you encounter memory pressure.
+
 ## Introduction
 
 **vLLM** is a fast and easy-to-use library for LLM inference and serving.

--- a/apps/vllm/ascend-0.20.2rc1-openeuler/data.yml
+++ b/apps/vllm/ascend-0.20.2rc1-openeuler/data.yml
@@ -1,0 +1,97 @@
+additionalProperties:
+  formFields:
+    - default: 8800
+      edit: true
+      envKey: PANEL_APP_PORT_HTTP
+      labelEn: Port
+      labelZh: 端口
+      required: true
+      rule: paramPort
+      type: number
+      label:
+        en: Port
+        es-es: Puerto
+        ja: ポート
+        ms: Port
+        pt-br: Porta
+        ru: Порт
+        zh-Hant: 埠
+        zh: 端口
+        ko: 포트
+        tr: Bağlantı Noktası
+    - default: /data01/models
+      edit: true
+      envKey: MODEL_DIR
+      labelEn: Model directory
+      labelZh: 模型目录
+      required: true
+      type: text
+      label:
+        en: Model directory
+        es-es: Directorio del modelo
+        ja: モデルディレクトリ
+        ms: Direktori model
+        pt-br: Diretório do modelo
+        ru: Каталог модели
+        zh-Hant: 模型目錄
+        zh: 模型目录
+        ko: 모델 디렉터리
+        tr: Model dizini
+    - default: Qwen3.6-35B-A3B
+      edit: true
+      envKey: MODEL_NAME
+      labelEn: Model name
+      labelZh: 模型名称
+      required: true
+      type: text
+      label:
+        en: Model name
+        es-es: Nombre del modelo
+        ja: モデル名
+        ms: Nama model
+        pt-br: Nome do modelo
+        ru: Название модели
+        zh-Hant: 模型名稱
+        zh: 模型名称
+        ko: 모델 이름
+        tr: Model adı
+    - default: 0,1
+      edit: true
+      envKey: ASCEND_RT_VISIBLE_DEVICES
+      labelEn: Ascend visible devices
+      labelZh: Ascend 可见设备
+      required: true
+      type: text
+      label:
+        en: Ascend visible devices
+        es-es: Dispositivos Ascend visibles
+        ja: Ascend 表示デバイス
+        ms: Peranti Ascend boleh dilihat
+        pt-br: Dispositivos Ascend visíveis
+        ru: Видимые устройства Ascend
+        zh-Hant: Ascend 可見設備
+        zh: Ascend 可见设备
+        ko: Ascend 표시 장치
+        tr: Ascend görünür cihazlar
+    - default: >-
+        /workspace/Qwen3.6-35B-A3B --served-model-name Qwen3.6-35B-A3B --host 0.0.0.0 --port 8001 --data-parallel-size 1 --tensor-parallel-size 2 --max-num-seqs 64 --max-model-len 262144 --max-num-batched-tokens 16384 --async-scheduling --trust-remote-code --gpu-memory-utilization 0.75 --enable-prefix-caching --enable-auto-tool-choice --enable-expert-parallel --tool-call-parser qwen3_coder --reasoning-parser qwen3
+        --speculative-config '{"method":"qwen3_5_mtp","num_speculative_tokens":3,"enforce_eager":true}'
+        --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+        --additional-config '{"enable_cpu_binding":true,"multistream_overlap_shared_expert":true}'
+      edit: true
+      envKey: START_COMMAND
+      labelEn: Start command
+      labelZh: 启动命令
+      required: true
+      type: text
+      label:
+        en: Start command
+        es-es: Comando de inicio
+        ja: 起動コマンド
+        ms: Arahan mula
+        pt-br: Comando de inicialização
+        ru: Команда запуска
+        zh-Hant: 啟動命令
+        zh: 启动命令
+        ko: 시작 명령
+        tr: Başlatma komutu

--- a/apps/vllm/ascend-0.20.2rc1-openeuler/docker-compose.yml
+++ b/apps/vllm/ascend-0.20.2rc1-openeuler/docker-compose.yml
@@ -1,0 +1,48 @@
+services:
+  vllm:
+    image: quay.io/ascend/vllm-ascend:v0.20.2rc1-openeuler
+    entrypoint:
+      - vllm
+      - serve
+    container_name: ${CONTAINER_NAME}
+    restart: always
+    privileged: true
+    security_opt:
+      - seccomp=unconfined
+    ipc: host
+    networks:
+      - 1panel-network
+    devices:
+      - /dev/davinci0:/dev/davinci0
+      - /dev/davinci1:/dev/davinci1
+      - /dev/davinci2:/dev/davinci2
+      - /dev/davinci3:/dev/davinci3
+      - /dev/davinci4:/dev/davinci4
+      - /dev/davinci5:/dev/davinci5
+      - /dev/davinci6:/dev/davinci6
+      - /dev/davinci7:/dev/davinci7
+      - /dev/davinci_manager:/dev/davinci_manager
+      - /dev/devmm_svm:/dev/devmm_svm
+      - /dev/hisi_hdc:/dev/hisi_hdc
+    volumes:
+      - ${MODEL_DIR}/:/workspace/${MODEL_NAME}
+      - /root/.cache:/root/.cache
+      - /usr/local/dcmi:/usr/local/dcmi
+      - /usr/local/bin/npu-smi:/usr/local/bin/npu-smi
+      - /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/
+      - /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info
+      - /etc/ascend_install.info:/etc/ascend_install.info
+    environment:
+      - ASCEND_RT_VISIBLE_DEVICES=${ASCEND_RT_VISIBLE_DEVICES}
+      - PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+      - HCCL_BUFFSIZE=1024
+      - OMP_PROC_BIND=false
+      - OMP_NUM_THREADS=1
+      - TASK_QUEUE_ENABLE=1
+    ports:
+      - ${PANEL_APP_PORT_HTTP}:8001
+    working_dir: /workspace
+    command: ${START_COMMAND}
+networks:
+  1panel-network:
+    external: true


### PR DESCRIPTION
## 背景
客户有 Atlas 800 / Atlas 300T Pro 等 910B NPU 部署需求，现有 310P 版本不兼容 910B/openEuler 镜像。

## 改动
- 新增 `apps/vllm/ascend-0.20.2rc1-openeuler/` 目录
  - `data.yml`：5 个表单字段（Port、MODEL_DIR、MODEL_NAME、ASCEND_RT_VISIBLE_DEVICES、START_COMMAND）
  - `docker-compose.yml`：镜像 `vllm-ascend:v0.20.2rc1-openeuler`，`ipc:host`、`privileged`、`seccomp=unconfined`，挂载 `davinci0-7` 设备 + 全部驱动目录，`HCCL_BUFFSIZE=1024`
- `START_COMMAND` 默认提供 Qwen3.6-35B-A3B 双卡 910B 最佳实践启动模板：
  - tensor-parallel-size 2
  - expert-parallel + auto-tool-choice
  - qwen3_5_mtp 投机解码（num_speculative_tokens=3）
  - FULL_DECODE_ONLY cudagraph
  - enable_cpu_binding + multistream_overlap_shared_expert
- `README.md` / `README_en.md`：在 310P 章节后追加 910B/openEuler 使用说明

## 验证
- YAML 均通过 PyYAML 解析
- `docker compose config` 识别为合法 Compose
- START_COMMAND 字面包含全部 12 个关键 token
- 模板与 `ascend-0.21.0rc1-310p` 风格一致（service 名 `vllm`、网络 `1panel-network`、全部 `${VAR}` 占位符）
