### PR TITLE
[Fix] homepage: Remove PUID and PGID to resolve Docker socket permission issue

### DIFF
--- a/apps/homepage/1.13.2/docker-compose.yml
+++ b/apps/homepage/1.13.2/docker-compose.yml
@@ -9,10 +9,8 @@ services:
       - "${PANEL_APP_PORT_HTTP}:3000"
     volumes:
       - ./config:/app/config
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     environment:
-      - PUID=1000
-      - PGID=1000
       - HOMEPAGE_ALLOWED_HOSTS=${HOMEPAGE_ALLOWED_HOSTS}
       - TZ=${TIME_ZONE}
     labels:  


### PR DESCRIPTION
- Remove PUID and PGID from environment variables to fix Docker socket permission issues.
- Make docker.sock read-only to ensure host safety.