### PR TITLE
fix(openresty): correct gzip defaults and add http.d for managed http directives

### DIFF
--- a/apps/openresty/1.31.1.1-2-4-noble/conf/nginx.conf
+++ b/apps/openresty/1.31.1.1-2-4-noble/conf/nginx.conf
@@ -37,11 +37,10 @@ http {
     gzip_min_length  1k;
     gzip_buffers     4 16k;
     gzip_http_version 1.1;
-    gzip_comp_level 2;
-    gzip_types     text/plain application/javascript application/x-javascript text/javascript text/css application/xml;
+    gzip_comp_level 5;
+    gzip_types     text/plain text/css text/xml text/javascript application/json application/ld+json application/javascript application/x-javascript application/xml application/xhtml+xml application/rss+xml application/atom+xml application/wasm image/svg+xml font/ttf font/otf;
     gzip_vary on;
-    gzip_proxied   expired no-cache no-store private auth;
-    gzip_disable   "MSIE [1-6]\.";
+    gzip_proxied   any;
 
     limit_conn_zone $binary_remote_addr zone=perip:10m;
     limit_conn_zone $server_name zone=perserver:10m;

--- a/apps/openresty/1.31.1.1-2-4-noble/conf/nginx.conf
+++ b/apps/openresty/1.31.1.1-2-4-noble/conf/nginx.conf
@@ -46,6 +46,7 @@ http {
     limit_conn_zone $binary_remote_addr zone=perip:10m;
     limit_conn_zone $server_name zone=perserver:10m;
 
+    include /usr/local/openresty/nginx/conf/http.d/*.conf;
     include /usr/local/openresty/nginx/conf/conf.d/*.conf;
     include /usr/local/openresty/nginx/conf/default/*.conf;
     include /usr/local/openresty/1pwaf/data/conf/waf.conf;

--- a/apps/openresty/1.31.1.1-2-4-noble/docker-compose.yml
+++ b/apps/openresty/1.31.1.1-2-4-noble/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - ./conf/default:/usr/local/openresty/nginx/conf/default/
       - ./conf/ssl:/usr/local/openresty/nginx/conf/ssl/
       - ./conf/modules-enabled:/usr/local/openresty/nginx/conf/modules-enabled/:ro
+      - ./conf/http.d:/usr/local/openresty/nginx/conf/http.d/:ro
       - ./modules:/usr/local/openresty/nginx/modules/1panel/:ro
       - ./log:/var/log/nginx
       - ./root:/usr/share/nginx/html

--- a/apps/openresty/1.31.1.1-2-4-noble/scripts/init.sh
+++ b/apps/openresty/1.31.1.1-2-4-noble/scripts/init.sh
@@ -2,7 +2,7 @@
 
 source ./.env
 
-mkdir -p modules conf/modules-enabled
+mkdir -p modules conf/modules-enabled conf/http.d
 
 sed -i -E "s/(listen[[:space:]]+)80([[:space:]]*default_server;)/\1${PANEL_APP_PORT_HTTP}\2/" conf/default/00.default.conf
 sed -i -E "s/(listen[[:space:]]+)\[::]:80([[:space:]]*default_server;)/\1\[::]:${PANEL_APP_PORT_HTTP}\2/" conf/default/00.default.conf

--- a/apps/openresty/1.31.1.1-2-4-noble/scripts/init.sh
+++ b/apps/openresty/1.31.1.1-2-4-noble/scripts/init.sh
@@ -2,7 +2,7 @@
 
 source ./.env
 
-mkdir -p modules conf/modules-enabled conf/http.d
+mkdir -p modules conf/modules-enabled
 
 sed -i -E "s/(listen[[:space:]]+)80([[:space:]]*default_server;)/\1${PANEL_APP_PORT_HTTP}\2/" conf/default/00.default.conf
 sed -i -E "s/(listen[[:space:]]+)\[::]:80([[:space:]]*default_server;)/\1\[::]:${PANEL_APP_PORT_HTTP}\2/" conf/default/00.default.conf

--- a/apps/openresty/1.31.1.1-2-4-noble/scripts/upgrade.sh
+++ b/apps/openresty/1.31.1.1-2-4-noble/scripts/upgrade.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 NGINX_CONF="conf/nginx.conf"
 MODULE_INCLUDE="include /usr/local/openresty/nginx/conf/modules-enabled/*.conf;"
-HTTP_INCLUDE="include /usr/local/openresty/nginx/conf/http.d/*.conf;"
-SITE_INCLUDE="include /usr/local/openresty/nginx/conf/conf.d/*.conf;"
 
-mkdir -p modules conf/modules-enabled conf/http.d
+mkdir -p modules conf/modules-enabled
 
 if [ ! -f "$NGINX_CONF" ]; then
     echo "✗ failed:  $NGINX_CONF not found"
@@ -13,24 +11,6 @@ fi
 
 if ! grep -Fq "$MODULE_INCLUDE" "$NGINX_CONF"; then
     sed -i "1i$MODULE_INCLUDE" "$NGINX_CONF"
-fi
-
-# http.d holds panel-managed http-context directives (compression, module
-# runtime settings). It must be included before conf.d so that per-site
-# configuration keeps overriding the global defaults.
-if ! grep -Fq "$HTTP_INCLUDE" "$NGINX_CONF"; then
-    if grep -Fq "$SITE_INCLUDE" "$NGINX_CONF"; then
-        awk -v site="$SITE_INCLUDE" -v http="$HTTP_INCLUDE" '
-            !done && index($0, site) {
-                match($0, /^[ \t]*/)
-                printf "%s%s\n", substr($0, 1, RLENGTH), http
-                done = 1
-            }
-            { print }
-        ' "$NGINX_CONF" > "$NGINX_CONF.tmp" && mv "$NGINX_CONF.tmp" "$NGINX_CONF"
-    else
-        echo "! skipped: conf.d include not found, add '$HTTP_INCLUDE' to the http block manually"
-    fi
 fi
 
 STREAM_BLOCK='stream {

--- a/apps/openresty/1.31.1.1-2-4-noble/scripts/upgrade.sh
+++ b/apps/openresty/1.31.1.1-2-4-noble/scripts/upgrade.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 NGINX_CONF="conf/nginx.conf"
 MODULE_INCLUDE="include /usr/local/openresty/nginx/conf/modules-enabled/*.conf;"
+HTTP_INCLUDE="include /usr/local/openresty/nginx/conf/http.d/*.conf;"
+SITE_INCLUDE="include /usr/local/openresty/nginx/conf/conf.d/*.conf;"
 
-mkdir -p modules conf/modules-enabled
+mkdir -p modules conf/modules-enabled conf/http.d
 
 if [ ! -f "$NGINX_CONF" ]; then
     echo "✗ failed:  $NGINX_CONF not found"
@@ -11,6 +13,24 @@ fi
 
 if ! grep -Fq "$MODULE_INCLUDE" "$NGINX_CONF"; then
     sed -i "1i$MODULE_INCLUDE" "$NGINX_CONF"
+fi
+
+# http.d holds panel-managed http-context directives (compression, module
+# runtime settings). It must be included before conf.d so that per-site
+# configuration keeps overriding the global defaults.
+if ! grep -Fq "$HTTP_INCLUDE" "$NGINX_CONF"; then
+    if grep -Fq "$SITE_INCLUDE" "$NGINX_CONF"; then
+        awk -v site="$SITE_INCLUDE" -v http="$HTTP_INCLUDE" '
+            !done && index($0, site) {
+                match($0, /^[ \t]*/)
+                printf "%s%s\n", substr($0, 1, RLENGTH), http
+                done = 1
+            }
+            { print }
+        ' "$NGINX_CONF" > "$NGINX_CONF.tmp" && mv "$NGINX_CONF.tmp" "$NGINX_CONF"
+    else
+        echo "! skipped: conf.d include not found, add '$HTTP_INCLUDE' to the http block manually"
+    fi
 fi
 
 STREAM_BLOCK='stream {


### PR DESCRIPTION
## Body

Applies to `1.31.1.1-2-4-noble` only. Older versions ship neither
`module.catalog.json` nor `Dockerfile.modules`, so `nginxModuleDynamicSupported`
returns false for them and they cannot use dynamic modules at all.

Companion PR: https://github.com/1Panel-dev/1Panel/pull/13639. **This one must be merged first** —
without the include added here, the files the panel writes to `conf/http.d`
are never loaded. The panel probes for the directory and stays inert when it is
missing, so merging out of order degrades silently rather than breaking.

## 1. gzip defaults

These values have been unchanged since 1.21.4.3 and no longer match how sites
are served today.

| Directive | Before | After | Why |
|---|---|---|---|
| `gzip_types` | no `application/json` | +json, ld+json, text/xml, xhtml+xml, rss+xml, atom+xml, wasm, svg+xml, ttf, otf | JSON API responses were served uncompressed. For an API-backed site this is the single largest loss in the whole file. |
| `gzip_comp_level` | `2` | `5` | Level 2 gives up roughly 8–15% ratio on text; 5 sits at the cost/ratio knee. |
| `gzip_proxied` | `expired no-cache no-store private auth` | `any` | The old value only compressed proxied responses carrying those specific Cache-Control semantics. A common upstream response such as `Cache-Control: public, max-age=3600` matched no condition and was never compressed — this affected reverse-proxy sites, one of the main use cases. |
| `gzip_disable` | `"MSIE [1-6]\."` | removed | A per-request User-Agent regex for browsers with no measurable share. |

Already compressed formats (images other than SVG, woff/woff2, archives, media)
are deliberately excluded: recompressing them costs CPU and usually grows the
payload.

`gzip_static` is intentionally **not** enabled. nginx does not verify that a
`.gz` file is newer than its source, so a stale artifact would be served
indefinitely with no error. The module stays compiled in and can be enabled
per site by users who generate `.gz` at build time.

## 2. `conf/http.d`

A directory for http-context directives that 1Panel generates and owns,
mounted read-only into the container.

`conf/modules-enabled` cannot serve this purpose: `load_module` is a
main-context directive, so that directory is included at the top level of
nginx.conf and cannot host http-context directives such as `brotli on`.

The include is emitted **before** `conf.d/*.conf` so per-site configuration
keeps overriding these panel-managed globals.

`upgrade.sh` injects the include into existing installations, mirroring the
handling already in place for the modules-enabled include. It is idempotent
and degrades to a warning when the `conf.d` include is absent, which happens
when a user has heavily customised nginx.conf.

## Testing

Verified against the real image with a real `ngx_brotli` `.so`, compiled using
this repo's own `Dockerfile.modules`.

- Fresh install: `init.sh` creates `conf/http.d`; `nginx -t` passes; include
  ordering confirmed (`http.d` at line 48, `conf.d` at 49).
- Upgrade from the pre-change layout: include injected at the right place with
  matching indentation; idempotent across three consecutive runs; `nginx -t`
  passes; every unrelated line preserved.
- Measured on a 16 KB JSON response: **16791 B → 1093 B** (−93.5%).
  HTML page: 9042 B → 146 B.

38 assertions across the fresh-install and upgrade suites, all passing.