### PR TITLE
chore: optimize AI Gateway metadata and OneDev Renovate rules

### DIFF
--- a/apps/ai-gateway/README.md
+++ b/apps/ai-gateway/README.md
@@ -1,8 +1,12 @@
 ## 产品介绍
 
-**[1Panel AI 网关](https://github.com/1Panel-dev/1Panel-Gateway)** 是面向企业和团队的 AI 统一接入与治理平台，提供模型代理、智能路由、权限控制、内容合规和用量分析等能力，让 AI 应用更安全、稳定、经济地使用不同模型资源。
+**1Panel AI 网关** 是面向企业和团队的 AI 统一接入与治理平台，提供模型代理、智能路由、权限控制、内容合规和用量分析等能力，让 AI 应用更安全、稳定、经济地使用不同模型资源。
 
 AI 应用只需配置统一的 Base URL 和 API Key，即可通过标准接口访问公有云 API、本地模型及其他模型服务。
+
+**扫码加入交流群**
+
+<img alt="扫码加入交流群" src="https://resource.fit2cloud.com/1panel/img/wechat.png" width="150" height="150">
 
 ## 主要功能
 

--- a/apps/ai-gateway/README_en.md
+++ b/apps/ai-gateway/README_en.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-**[1Panel AI Gateway](https://github.com/1Panel-dev/1Panel-Gateway)** is an enterprise AI access and governance platform. It provides model proxying, intelligent routing, permission control, content compliance, and usage analytics so applications can use different model resources securely, reliably, and efficiently.
+**1Panel AI Gateway** is an enterprise AI access and governance platform. It provides model proxying, intelligent routing, permission control, content compliance, and usage analytics so applications can use different model resources securely, reliably, and efficiently.
 
 Applications only need a unified Base URL and API key to access public cloud APIs, local models, and other model services through standard interfaces.
 

--- a/apps/ai-gateway/data.yml
+++ b/apps/ai-gateway/data.yml
@@ -1,26 +1,26 @@
 name: "1Panel AI 网关"
 tags:
   - AI
-title: "企业级 AI 网关"
-description: "企业级 AI 网关"
+title: "企业级 AI 模型统一接入与治理平台"
+description: "企业级 AI 模型统一接入与治理平台"
 additionalProperties:
   key: ai-gateway
   name: "1Panel AI 网关"
   tags:
     - AI
-  shortDescZh: "企业级 AI 网关"
-  shortDescEn: "Enterprise-grade AI gateway"
+  shortDescZh: "企业级 AI 模型统一接入与治理平台"
+  shortDescEn: "Enterprise-grade platform for unified AI model access and governance"
   description:
-    en: "Enterprise-grade AI gateway"
-    es-es: "Enterprise-grade AI gateway"
-    ja: "Enterprise-grade AI gateway"
-    ms: "Enterprise-grade AI gateway"
-    pt-br: "Enterprise-grade AI gateway"
-    ru: "Enterprise-grade AI gateway"
-    ko: "Enterprise-grade AI gateway"
-    zh-Hant: "企業級 AI 網關"
-    zh: "企业级 AI 网关"
-    tr: "Enterprise-grade AI gateway"
+    en: "Enterprise-grade platform for unified AI model access and governance"
+    es-es: "Plataforma empresarial para el acceso unificado y la gobernanza de modelos de IA"
+    ja: "統一されたAIモデルアクセスとガバナンスのためのエンタープライズプラットフォーム"
+    ms: "Platform perusahaan untuk akses dan tadbir urus model AI yang disatukan"
+    pt-br: "Plataforma empresarial para acesso unificado e governança de modelos de IA"
+    ru: "Корпоративная платформа для унифицированного доступа к моделям ИИ и их управления"
+    ko: "통합 AI 모델 액세스 및 거버넌스를 위한 엔터프라이즈 플랫폼"
+    zh-Hant: "企業級 AI 模型統一接入與治理平台"
+    zh: "企业级 AI 模型统一接入与治理平台"
+    tr: "Kurumsal düzeyde AI modeli için birleşik erişim ve yönetim platformu"
   type: website
   crossVersionUpdate: true
   recommend: 1
@@ -28,6 +28,6 @@ additionalProperties:
   architectures:
     - amd64
     - arm64
-  website: https://docs.fit2cloud.com/1Panel-Gateway
+  website: https://1panel.cn/ai-gateway.html
   github: https://github.com/1Panel-dev/1Panel-Gateway
   document: https://docs.fit2cloud.com/1Panel-Gateway

--- a/renovate.json
+++ b/renovate.json
@@ -205,14 +205,6 @@
       "allowedVersions": "/^19.*/"
     },
     {
-      "matchFileNames": ["apps/onedev/12.*/*.yml"],
-      "allowedVersions": "/^12.*/"
-    },
-    {
-      "matchFileNames": ["apps/onedev/13.*/*.yml"],
-      "allowedVersions": "/^13.*/"
-    },
-    {
       "matchFileNames": ["apps/uptime-kuma/1.*/*.yml"],
       "allowedVersions": "/^1.*/"
     },


### PR DESCRIPTION
## 变更内容

- 优化 1Panel AI 网关的应用名称描述及多语言文案
- 将应用官网地址调整为 AI Gateway 产品页
- 优化中英文 README 展示，并在中文 README 中添加微信交流群二维码
- 删除 OneDev 12.x 和 13.x 的 Renovate 版本限制规则

## 验证

- data.yml YAML 解析通过
- renovate.json JSON 解析通过
- git diff --check 通过
- 微信二维码资源访问正常