### PR TITLE
feat(rocketmq): Dashboard 支持安装时配置登录认证

### DIFF
--- a/apps/rocketmq/5.5.0/data.yml
+++ b/apps/rocketmq/5.5.0/data.yml
@@ -140,3 +140,68 @@ additionalProperties:
       required: true
       rule: paramPort
       type: number
+    - default: "TRUE"
+      edit: true
+      envKey: DASHBOARD_LOGIN_REQUIRED
+      labelEn: Enable Dashboard Login
+      labelZh: 开启 Dashboard 登录认证
+      label:
+        en: Enable Dashboard Login
+        es-es: Habilitar inicio de sesión del Dashboard
+        fa: 'فعال‌سازی ورود به داشبورد'
+        ja: ダッシュボードログインを有効化
+        ms: Dayakan Log Masuk Papan Pemuka
+        pt-br: Ativar login do Painel
+        ru: Включить вход в панель управления
+        ko: 대시보드 로그인 활성화
+        zh: 开启 Dashboard 登录认证
+        zh-Hant: 開啟 Dashboard 登入認證
+        tr: Kontrol Paneli Girişini Etkinleştir
+      required: true
+      type: select
+      values:
+        - label: "TRUE"
+          value: "TRUE"
+        - label: "FALSE"
+          value: "FALSE"
+    - default: admin
+      edit: true
+      envKey: DASHBOARD_USER
+      labelEn: Dashboard Username
+      labelZh: Dashboard 用户名
+      label:
+        en: Dashboard Username
+        es-es: Dashboard Nombre de usuario
+        fa: 'نام کاربری داشبورد'
+        ja: ダッシュボードユーザー名
+        ms: Nama Pengguna Papan Pemuka
+        pt-br: Nome de Usuário do Painel
+        ru: Имя пользователя панели
+        ko: 대시보드 사용자 이름
+        zh: Dashboard 用户名
+        zh-Hant: Dashboard 使用者名稱
+        tr: Dashboard Kullanıcı Adı
+      required: true
+      rule: paramCommon
+      type: text
+    - default: Rocketmq@123
+      edit: true
+      envKey: DASHBOARD_PASSWORD
+      labelEn: Dashboard Password
+      labelZh: Dashboard 密码
+      label:
+        en: Dashboard Password
+        es-es: Dashboard Contraseña
+        fa: 'رمز عبور داشبورد'
+        ja: ダッシュボードパスワード
+        ms: Kata Laluan Papan Pemuka
+        pt-br: Senha do Painel
+        ru: Пароль панели
+        ko: 대시보드 비밀번호
+        zh: Dashboard 密码
+        zh-Hant: Dashboard 密碼
+        tr: Dashboard Parola
+      random: true
+      required: true
+      rule: paramCommon
+      type: password

--- a/apps/rocketmq/5.5.0/data.yml
+++ b/apps/rocketmq/5.5.0/data.yml
@@ -203,5 +203,5 @@ additionalProperties:
         tr: Dashboard Parola
       random: true
       required: true
-      rule: paramCommon
+      rule: paramComplexity
       type: password

--- a/apps/rocketmq/5.5.0/docker-compose.yml
+++ b/apps/rocketmq/5.5.0/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     labels:
       createdBy: "Apps"
   dashboard:
-    image: apacherocketmq/rocketmq-dashboard:latest
+    image: apacherocketmq/rocketmq-dashboard:2.1.0
     container_name: ${CONTAINER_NAME}-rmqdashboard
     links:
       - namesrv
@@ -66,7 +66,26 @@ services:
       - 1panel-network
     restart: on-failure
     environment:
-      - JAVA_OPTS=-Drocketmq.namesrv.addr=namesrv:9876
+      - JAVA_OPTS=-Drocketmq.namesrv.addr=namesrv:9876 -Drocketmq.config.loginRequired=${DASHBOARD_LOGIN_REQUIRED} -Drocketmq.config.authMode=file -Drocketmq.config.dataPath=/dashboard-data
+      - DASHBOARD_USER=${DASHBOARD_USER}
+      - DASHBOARD_PASSWORD=${DASHBOARD_PASSWORD}
+      - SPRING_SECURITY_USER_NAME=${DASHBOARD_USER}
+      - SPRING_SECURITY_USER_PASSWORD=${DASHBOARD_PASSWORD}
+    volumes:
+      - ./data/dashboard:/dashboard-data
+    entrypoint:
+      - sh
+      - -c
+      - |
+        mkdir -p /dashboard-data
+        GEN=$$(printf '%s=%s,1\n' "$$DASHBOARD_USER" "$$DASHBOARD_PASSWORD")
+        if [ ! -f /dashboard-data/users.properties ] || [ "$$(cat /dashboard-data/.users.properties.generated 2>/dev/null)" != "$$GEN" ]; then
+          printf '%s\n' "$$GEN" > /dashboard-data/users.properties
+          printf '%s' "$$GEN" > /dashboard-data/.users.properties.generated
+          chmod 600 /dashboard-data/users.properties /dashboard-data/.users.properties.generated
+          echo 'users.properties regenerated from DASHBOARD_USER/DASHBOARD_PASSWORD'
+        fi
+        exec java $$JAVA_OPTS -jar /rocketmq-dashboard.jar
     labels:
       createdBy: "Apps"
 networks:


### PR DESCRIPTION
## 改动说明

为 RocketMQ 应用（apps/rocketmq/5.5.0）的 Dashboard 增加安装时可配置的登录认证能力。

### 安装表单新增参数（5.5.0/data.yml）

| 参数 | envKey | 说明 |
|---|---|---|
| 开启 Dashboard 登录认证 | DASHBOARD_LOGIN_REQUIRED | 下拉选择 TRUE / FALSE，默认 TRUE |
| Dashboard 用户名 | DASHBOARD_USER | 管理员账号，默认 admin |
| Dashboard 密码 | DASHBOARD_PASSWORD | 密码类型表单项，安装时自动随机生成，可修改 |

### docker-compose.yml（仅 dashboard 服务）

- 镜像由 `:latest` 固定为 `:2.1.0`（当前与 latest 为同一 digest；按应用打包规范避免使用 :latest）
- `JAVA_OPTS` 追加：`-Drocketmq.config.loginRequired=${DASHBOARD_LOGIN_REQUIRED}`、`-Drocketmq.config.authMode=file`、`-Drocketmq.config.dataPath=/dashboard-data`（原 namesrv 参数保留）
- 通过 `SPRING_SECURITY_USER_NAME` / `SPRING_SECURITY_USER_PASSWORD` 同步覆盖 Spring Security 内置弱口令 rocketmq/1234567（用于保护 /actuator 端点），与应用登录共用同一套凭据
- 覆盖 entrypoint：容器启动前按表单凭据生成 `users.properties`（格式 `username=password,1`，管理员角色），凭据经容器环境变量在运行时展开，不进入命令字面量

### users.properties 生命周期设计

- 持久化挂载 `./data/dashboard:/dashboard-data`（即 dataPath）
- 仅当文件不存在、**或表单凭据发生变化**时才重写（通过 `.users.properties.generated` 标记文件对比实现）
- 普通重启 / 重建不会覆盖已有文件：dashboard 原生的 users.properties 热更新、手工添加的多用户配置在重启后保留
- 在 1Panel 中修改用户名 / 密码并重建后自动检测变化并重写，不会出现改了密码不生效的问题

## 上游依据（rocketmq-dashboard 源码 / 官方文档）

- 登录开关：`rocketmq.config.loginRequired=true`；application.yml 注释明确 "must create userInfo file: ${rocketmq.config.dataPath}/users.properties if the login is required"
- 用户文件默认路径 `/tmp/rocketmq-console/data`；文件存在则加载并支持热更新，不存在时才回退到镜像内置默认账号
- `users.properties` 格式：`username=password[,N]`，N=1 为管理员
- 镜像 ENTRYPOINT 为 `sh -c "java $JAVA_OPTS -jar /rocketmq-dashboard.jar"`（src/main/docker/Dockerfile），覆盖 entrypoint 后原样保留启动命令
- 2.x 默认 `server.port=8082`，与本应用现有端口映射一致
- `rocketmq.namesrv.addr` 系统属性在 2.x 中仍被 RMQConfigure 原生支持，原配置无需改动

## 注意事项

- users.properties 基于 Java Properties 解析，用户名 / 密码请避免使用英文逗号与反斜杠
- 登录认证默认开启，可通过表单开关（TRUE/FALSE）随时启停
- 本地测试：将 apps/rocketmq 复制到 /opt/1panel/resource/apps/local/rocketmq 后在 1Panel 中安装验证
