### PR TITLE
feat(emlog): add pro-latest-php8.2-apache version

### DIFF
--- a/apps/emlog/data.yml
+++ b/apps/emlog/data.yml
@@ -31,4 +31,3 @@ additionalProperties:
     architectures:
       - amd64
       - arm64
-      - arm/v7

--- a/apps/emlog/pro-latest-php8.2-apache/data.yml
+++ b/apps/emlog/pro-latest-php8.2-apache/data.yml
@@ -1,0 +1,129 @@
+additionalProperties:
+  formFields:
+    - child:
+        default: ""
+        envKey: PANEL_DB_HOST
+        required: true
+        type: service
+      default: mysql
+      envKey: PANEL_DB_TYPE
+      labelEn: Database Service
+      labelZh: 数据库服务
+      label:
+        en: Database Service
+        zh: 数据库服务
+        es-es: Servicio de base de datos
+        fa: 'سرویس پایگاه داده'
+        zh-Hant: 資料庫服務
+        ja: データベースサービス
+        ko: 데이터베이스 서비스
+        ms: Perkhidmatan Pangkalan Data
+        pt-br: Serviço de Banco de Dados
+        ru: Сервис баз данных
+        tr: Veritabanı Hizmeti
+      required: true
+      type: apps
+      values:
+        - label: MySQL
+          value: mysql
+        - label: MariaDB
+          value: mariadb
+    - default: emlog
+      envKey: PANEL_DB_NAME
+      labelEn: Database
+      labelZh: 数据库名
+      label:
+        en: Database
+        zh: 数据库名
+        es-es: Base de datos
+        fa: 'پایگاه داده'
+        zh-Hant: 數據庫名
+        ja: データベース
+        ko: 데이터베이스
+        ms: Pangkalan Data
+        pt-br: Banco de Dados
+        ru: База данных
+        tr: Veritabanı
+      random: true
+      required: true
+      rule: paramCommon
+      type: text
+    - default: emlog
+      envKey: PANEL_DB_USER
+      labelEn: Database User
+      labelZh: 数据库用户
+      label:
+        en: Database User
+        zh: 数据库用户
+        es-es: Usuario de la base de datos
+        fa: 'کاربر پایگاه داده'
+        zh-Hant: 數據庫用戶
+        ja: データベースユーザー
+        ko: 데이터베이스 사용자
+        ms: Pengguna Pangkalan Data
+        pt-br: Usuário do Banco de Dados
+        ru: Пользователь базы данных
+        tr: Veritabanı Kullanıcısı
+      random: true
+      required: true
+      rule: paramCommon
+      type: text
+    - default: emlog
+      envKey: PANEL_DB_USER_PASSWORD
+      labelEn: Database User Password
+      labelZh: 数据库用户密码
+      label:
+        en: Database User Password
+        zh: 数据库用户密码
+        es-es: Contraseña del usuario de la base de datos
+        fa: 'رمز عبور کاربر پایگاه داده'
+        zh-Hant: 資料庫使用者密碼
+        ja: データベースユーザーパスワード
+        ko: 데이터베이스 사용자 비밀번호
+        ms: Kata laluan pengguna pangkalan data
+        pt-br: Senha do usuário do banco de dados
+        ru: Пароль пользователя базы данных
+        tr: Veritabanı kullanıcı parolası
+      random: true
+      required: true
+      type: password
+    - default: 8080
+      edit: true
+      envKey: PANEL_APP_PORT_HTTP
+      labelEn: Port
+      labelZh: 端口，建议填写 8080，然后在【网站】管理中安装 OpenResty，创建网站关联emlog应用，暴露80、443端口
+      label:
+        en: Port
+        zh: 端口，建议填写 8080，然后在【网站】管理中安装 OpenResty，创建网站关联emlog应用，暴露80、443端口
+        es-es: Puerto
+        fa: 'پورت'
+        zh-Hant: 埠
+        ja: ポート
+        ko: 포트
+        ms: Port
+        pt-br: Porta
+        ru: Порт
+        tr: Bağlantı Noktası
+      required: true
+      rule: paramPort
+      type: number
+    - default: localhost
+      edit: true
+      envKey: EMLOG_EXTERNAL_URL
+      labelEn: site domain
+      labelZh: 域名，建议填写 localhost， 然后在【网站】管理中安装 OpenResty，创建网站关联emlog应用绑定域名
+      label:
+        en: site domain
+        zh: 域名，建议填写 localhost， 然后在【网站】管理中安装 OpenResty，创建网站关联emlog应用绑定域名
+        es-es: dominio del sitio
+        fa: 'دامنه سایت'
+        zh-Hant: 站點網域
+        ja: サイトドメイン
+        ko: 사이트 도메인
+        ms: Domain laman
+        pt-br: Domínio do site
+        ru: Домен сайта
+        tr: Site alan adı
+      required: true
+      rule: paramExtUrl
+      type: text

--- a/apps/emlog/pro-latest-php8.2-apache/docker-compose.yml
+++ b/apps/emlog/pro-latest-php8.2-apache/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  emlog:
+    image: emlog/emlog:pro-latest-php8.2-apache
+    container_name: ${CONTAINER_NAME}
+    restart: always
+    environment:
+      - EMLOG_DB_HOST=${PANEL_DB_HOST}
+      - EMLOG_DB_NAME=${PANEL_DB_NAME}
+      - EMLOG_DB_USER=${PANEL_DB_USER}
+      - EMLOG_DB_PASSWORD=${PANEL_DB_USER_PASSWORD}
+      - EMLOG_DOMAIN_NAME=${EMLOG_EXTERNAL_URL}
+    ports:
+      - ${PANEL_APP_PORT_HTTP}:80
+    networks:
+      - 1panel-network
+    volumes:
+      - ./data:/app
+    labels:
+      createdBy: "Apps"
+networks:
+  1panel-network:
+    external: true


### PR DESCRIPTION
### Description

1. **Add new version `pro-latest-php8.2-apache`**:
   - Added `apps/emlog/pro-latest-php8.2-apache` directory using `emlog/emlog:pro-latest-php8.2-apache` image.
2. **Retain `pro-latest-php7.4-apache`**:
   - Retained the existing `apps/emlog/pro-latest-php7.4-apache` version directory for backwards compatibility.
3. **Update supported architectures**:
   - Removed `arm/v7` from `apps/emlog/data.yml`, keeping `amd64` and `arm64`.